### PR TITLE
improved error handling for function calls

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/Expression.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/Expression.java
@@ -18,10 +18,13 @@ package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 
+import javax.annotation.Nullable;
+
 public interface Expression {
 
     boolean isConstant();
 
+    @Nullable
     Object evaluate(EvaluationContext context);
 
     Class getType();

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/FieldAccessExpression.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/FieldAccessExpression.java
@@ -42,7 +42,11 @@ public class FieldAccessExpression implements Expression {
     @Override
     public Object evaluate(EvaluationContext context) {
         final Object bean = this.object.evaluate(context);
-        final String fieldName = field.evaluate(context).toString();
+        final Object fieldValue = field.evaluate(context);
+        if (bean == null || fieldValue == null) {
+            return null;
+        }
+        final String fieldName = fieldValue.toString();
         try {
             Object property = PropertyUtils.getProperty(bean, fieldName);
             if (property == null) {

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/FunctionExpression.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/FunctionExpression.java
@@ -23,11 +23,15 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 
 public class FunctionExpression implements Expression {
+    private final int line;
+    private final int charPositionInLine;
     private final FunctionArgs args;
     private final Function<?> function;
     private final FunctionDescriptor descriptor;
 
-    public FunctionExpression(FunctionArgs args) {
+    public FunctionExpression(int line, int charPositionInLine, FunctionArgs args) {
+        this.line = line;
+        this.charPositionInLine = charPositionInLine;
         this.args = args;
         this.function = args.getFunction();
         this.descriptor = this.function.descriptor();
@@ -51,7 +55,12 @@ public class FunctionExpression implements Expression {
 
     @Override
     public Object evaluate(EvaluationContext context) {
-        return descriptor.returnType().cast(function.evaluate(args, context));
+        try {
+            return descriptor.returnType().cast(function.evaluate(args, context));
+        } catch (Exception e) {
+            context.addEvaluationError(line, charPositionInLine, descriptor, e);
+            return null;
+        }
     }
 
     @Override

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/IndexedAccessExpression.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/IndexedAccessExpression.java
@@ -42,6 +42,9 @@ public class IndexedAccessExpression implements Expression {
     public Object evaluate(EvaluationContext context) {
         final Object idxObj = this.index.evaluate(context);
         final Object indexable = indexableObject.evaluate(context);
+        if (idxObj == null || indexable == null) {
+            return null;
+        }
 
         if (idxObj instanceof Long) {
             int idx = Ints.saturatedCast((long) idxObj);

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/MessageRefExpression.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/MessageRefExpression.java
@@ -33,6 +33,9 @@ public class MessageRefExpression implements Expression {
     @Override
     public Object evaluate(EvaluationContext context) {
         final Object fieldName = fieldExpr.evaluate(context);
+        if (fieldName == null) {
+            return null;
+        }
         return context.currentMessage().getField(fieldName.toString());
     }
 

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/ast/functions/ParameterDescriptor.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/ast/functions/ParameterDescriptor.java
@@ -87,6 +87,7 @@ public abstract class ParameterDescriptor<T, R> {
         return ParameterDescriptor.<T, R>param().type(typeClass).transformedType(transformedClass).name(name);
     }
 
+    @Nullable
     public R required(FunctionArgs args, EvaluationContext context) {
         final Object precomputedValue = args.getPreComputedValue(name());
         if (precomputedValue != null) {

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/StringConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/StringConversion.java
@@ -59,6 +59,9 @@ public class StringConversion extends AbstractFunction<String> {
     @Override
     public String evaluate(FunctionArgs args, EvaluationContext context) {
         final Object evaluated = valueParam.required(args, context);
+        if (evaluated == null) {
+            return null;
+        }
         // fast path for the most common targets
         if (evaluated instanceof String
                 || evaluated instanceof Number

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/FormatDate.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/FormatDate.java
@@ -51,6 +51,9 @@ public class FormatDate extends AbstractFunction<String> {
     public String evaluate(FunctionArgs args, EvaluationContext context) {
         final DateTime dateTime = value.required(args, context);
         final DateTimeFormatter formatter = format.required(args, context);
+        if (dateTime == null || formatter == null) {
+            return null;
+        }
         final DateTimeZone timeZone = timeZoneParam.optional(args, context).orElse(DateTimeZone.UTC);
 
         return formatter.withZone(timeZone).print(dateTime);

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/ParseDate.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/ParseDate.java
@@ -55,6 +55,9 @@ public class ParseDate extends TimezoneAwareFunction {
     public DateTime evaluate(FunctionArgs args, EvaluationContext context, DateTimeZone timezone) {
         final String dateString = valueParam.required(args, context);
         final String pattern = patternParam.required(args, context);
+        if (dateString == null || pattern == null) {
+            return null;
+        }
         final DateTimeFormatter formatter = DateTimeFormat.forPattern(pattern).withZone(timezone);
 
         return formatter.parseDateTime(dateString);

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/CidrMatch.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/CidrMatch.java
@@ -51,7 +51,9 @@ public class CidrMatch extends AbstractFunction<Boolean> {
     public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
         final CIDR cidr = cidrParam.required(args, context);
         final IpAddress ipAddress = ipParam.required(args, context);
-
+        if (cidr == null || ipAddress == null) {
+            return null;
+        }
         return cidr.contains(ipAddress.inetAddress());
     }
 

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/SelectJsonPath.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/SelectJsonPath.java
@@ -66,7 +66,9 @@ public class SelectJsonPath extends AbstractFunction<Map<String, Object>> {
     public Map<String, Object> evaluate(FunctionArgs args, EvaluationContext context) {
         final JsonNode json = jsonParam.required(args, context);
         final Map<String, JsonPath> paths = pathsParam.required(args, context);
-
+        if (json == null || paths == null) {
+            return null;
+        }
         return paths
                 .entrySet().stream()
                 .collect(toMap(

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/Abbreviate.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/Abbreviate.java
@@ -42,7 +42,11 @@ public class Abbreviate extends AbstractFunction<String> {
     @Override
     public String evaluate(FunctionArgs args, EvaluationContext context) {
         final String value = valueParam.required(args, context);
-        final Long maxWidth = Math.max(widthParam.required(args, context), 4L);
+        final Long required = widthParam.required(args, context);
+        if (required == null) {
+            return null;
+        }
+        final Long maxWidth = Math.max(required, 4L);
 
         return StringUtils.abbreviate(value, saturatedCast(maxWidth));
     }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/Substring.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/Substring.java
@@ -42,7 +42,11 @@ public class Substring extends AbstractFunction<String> {
     @Override
     public String evaluate(FunctionArgs args, EvaluationContext context) {
         final String value = valueParam.required(args, context);
-        final int start = Ints.saturatedCast(startParam.required(args, context));
+        final Long startValue = startParam.required(args, context);
+        if (value == null || startValue == null) {
+            return null;
+        }
+        final int start = Ints.saturatedCast(startValue);
         final int end = Ints.saturatedCast(endParam.optional(args, context).orElse((long) value.length()));
 
         return StringUtils.substring(value, start, end);

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
@@ -347,7 +347,8 @@ public class PipelineRuleParser {
             }
 
             final FunctionExpression expr = new FunctionExpression(
-                     new FunctionArgs(functionRegistry.resolveOrError(name), argsMap)
+                    ctx.getStart().getLine(), ctx.getStart().getCharPositionInLine(),
+                    new FunctionArgs(functionRegistry.resolveOrError(name), argsMap)
             );
 
             log.trace("FUNC: ctx {} => {}", ctx, expr);

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -251,7 +251,7 @@ public class PipelineInterpreter implements MessageProcessor {
                             if (rule.when().evaluateBool(context)) {
                                 if (context.hasEvaluationErrors()) {
                                     final EvaluationContext.EvalError lastError = Iterables.getLast(context.evaluationErrors());
-                                    appendProcessingError(message, lastError.toString());
+                                    appendProcessingError(rule, message, lastError.toString());
                                     log.debug("Encountered evaluation error during condition, skipping rule actions: {}",
                                               lastError);
                                     continue;
@@ -269,7 +269,7 @@ public class PipelineInterpreter implements MessageProcessor {
                                 if (context.hasEvaluationErrors()) {
                                     // if the last statement resulted in an error, do not continue to execute this rules
                                     final EvaluationContext.EvalError lastError = Iterables.getLast(context.evaluationErrors());
-                                    appendProcessingError(message, lastError.toString());
+                                    appendProcessingError(rule, message, lastError.toString());
                                     log.debug("Encountered evaluation error, skipping rest of the rule: {}",
                                               lastError);
                                     break;
@@ -329,11 +329,12 @@ public class PipelineInterpreter implements MessageProcessor {
         return new MessageCollection(fullyProcessed);
     }
 
-    private void appendProcessingError(Message message, String errorString) {
+    private void appendProcessingError(Rule rule, Message message, String errorString) {
+        final String msg = "For rule '" + rule.name() + "': " + errorString;
         if (message.hasField("gl2_processing_error")) {
-            message.addField("gl2_processing_error", message.getFieldAs(String.class, "gl2_processor_error") + "," + errorString);
+            message.addField("gl2_processing_error", message.getFieldAs(String.class, "gl2_processor_error") + "," + msg);
         } else {
-            message.addField("gl2_processing_error", errorString);
+            message.addField("gl2_processing_error", msg);
         }
     }
 

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -73,6 +73,8 @@ import static org.jooq.lambda.tuple.Tuple.tuple;
 public class PipelineInterpreter implements MessageProcessor {
     private static final Logger log = LoggerFactory.getLogger(PipelineInterpreter.class);
 
+    public static final String GL2_PROCESSING_ERROR = "gl2_processing_error";
+
     private final RuleService ruleService;
     private final PipelineService pipelineService;
     private final PipelineStreamConnectionsService pipelineStreamConnectionsService;
@@ -331,10 +333,10 @@ public class PipelineInterpreter implements MessageProcessor {
 
     private void appendProcessingError(Rule rule, Message message, String errorString) {
         final String msg = "For rule '" + rule.name() + "': " + errorString;
-        if (message.hasField("gl2_processing_error")) {
-            message.addField("gl2_processing_error", message.getFieldAs(String.class, "gl2_processor_error") + "," + msg);
+        if (message.hasField(GL2_PROCESSING_ERROR)) {
+            message.addField(GL2_PROCESSING_ERROR, message.getFieldAs(String.class, GL2_PROCESSING_ERROR) + "," + msg);
         } else {
-            message.addField("gl2_processing_error", msg);
+            message.addField(GL2_PROCESSING_ERROR, msg);
         }
     }
 

--- a/src/test/java/org/graylog/plugins/pipelineprocessor/BaseParserTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/BaseParserTest.java
@@ -79,6 +79,17 @@ public class BaseParserTest {
         actionsTriggered.set(false);
     }
 
+    protected EvaluationContext contextForRuleEval(Rule rule, Message message) {
+        final EvaluationContext context = new EvaluationContext(message);
+        if (rule.when().evaluateBool(context)) {
+
+            for (Statement statement : rule.then()) {
+                statement.evaluate(context);
+            }
+        }
+        return context;
+    }
+
     protected Message evaluateRule(Rule rule, Message message) {
         final EvaluationContext context = new EvaluationContext(message);
         if (rule.when().evaluateBool(context)) {

--- a/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -17,7 +17,9 @@
 package org.graylog.plugins.pipelineprocessor.functions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Iterables;
 import org.graylog.plugins.pipelineprocessor.BaseParserTest;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.BooleanConversion;
@@ -258,4 +260,14 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("ipv6_anon")).isEqualTo("2001:db8::");
     }
 
+    @Test
+    public void evalError() {
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+
+        final EvaluationContext context = contextForRuleEval(rule, new Message("test", "test", Tools.nowUTC()));
+
+        assertThat(context).isNotNull();
+        assertThat(context.hasEvaluationErrors()).isTrue();
+        assertThat(Iterables.getLast(context.evaluationErrors()).toString()).isEqualTo("In call to function 'toip' at 5:28 an exception was thrown: 'null' is not an IP string literal.");
+    }
 }

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/evalError.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/evalError.txt
@@ -1,0 +1,6 @@
+rule "trigger null"
+when
+  true
+then
+  set_field("this_is_null", toip($message.does_not_exist));
+end


### PR DESCRIPTION
 - Function::evaluate is now marked as Nullable
 - ParameterDescriptor::required is marked as Nullable
 - FunctionExpression catches all exceptions and adds them to the evaluation context
 - the pipeline interpreter adds eval errors to the message in a special field (gl2_processing_error)
 - all expressions properly handle null values and return null values where appropriate
 - all built-in functions properly handle null values for required parameters and return null where appropriate
 - other null accesses in functions will trigger an exception caught be the function expressions
 - added test case for simple null value check