### PR TITLE
Rule details page

### DIFF
--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -4,16 +4,18 @@ import PipelinesOverviewPage from 'pipelines/PipelinesOverviewPage';
 import PipelineDetailsPage from 'pipelines/PipelineDetailsPage';
 import PipelineConnectionsPage from 'pipeline-connections/PipelineConnectionsPage';
 import RulesPage from 'rules/RulesPage';
+import RuleDetailsPage from 'rules/RuleDetailsPage';
 
 PluginStore.register(new PluginManifest(packageJson, {
   routes: [
-    {path: '/system/pipelines', component: PipelineConnectionsPage},
-    {path: '/system/pipelines/overview', component: PipelinesOverviewPage},
-    {path: '/system/pipelines/rules', component: RulesPage},
-    {path: '/system/pipelines/:pipelineId', component: PipelineDetailsPage},
+    { path: '/system/pipelines', component: PipelineConnectionsPage },
+    { path: '/system/pipelines/overview', component: PipelinesOverviewPage },
+    { path: '/system/pipelines/rules', component: RulesPage },
+    { path: '/system/pipelines/rules/:ruleId', component: RuleDetailsPage },
+    { path: '/system/pipelines/:pipelineId', component: PipelineDetailsPage },
   ],
 
   systemnavigation: [
-    {path: '/system/pipelines', description: 'Pipelines'},
+    { path: '/system/pipelines', description: 'Pipelines' },
   ],
 }));

--- a/src/web/pipelines/Stage.jsx
+++ b/src/web/pipelines/Stage.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import Reflux from 'reflux';
 import { Col, Button } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 import { DataTable, EntityListItem, Spinner } from 'components/common';
 import RulesStore from 'rules/RulesStore';
@@ -22,7 +23,11 @@ const Stage = React.createClass({
   _ruleRowFormatter(rule) {
     return (
       <tr>
-        <td style={{ width: 400 }}>{rule.title}</td>
+        <td style={{ width: 400 }}>
+          <LinkContainer to={`/system/pipelines/rules/${rule.id}`}>
+            <a>{rule.title}</a>
+          </LinkContainer>
+        </td>
         <td>{rule.description}</td>
       </tr>
     );

--- a/src/web/rules/Rule.jsx
+++ b/src/web/rules/Rule.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Row, Col, Button } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
+
+import { PageHeader } from 'components/common';
+import DocumentationLink from 'components/support/DocumentationLink';
+
+import DocsHelper from 'util/DocsHelper';
+
+import RuleForm from './RuleForm';
+import RuleHelper from './RuleHelper';
+
+const Rule = React.createClass({
+  propTypes: {
+    rule: React.PropTypes.object,
+    create: React.PropTypes.bool,
+    onSave: React.PropTypes.func.isRequired,
+    validateRule: React.PropTypes.func.isRequired,
+    history: React.PropTypes.object.isRequired,
+  },
+
+  render() {
+    let title;
+    if (this.props.create) {
+      title = 'Create pipeline rule';
+    } else {
+      title = <span>Pipeline rule <em>{this.props.rule.title}</em></span>;
+    }
+
+    return (
+      <div>
+        <PageHeader title={title} titleSize={9} buttonSize={3}>
+          <span>
+            Rules are a way of applying changes to messages in Graylog. A rule consists of a condition and a list{' '}
+            of actions.{' '}
+            Graylog evaluates the condition against a message and executes the actions if the condition is satisfied.
+          </span>
+
+          <span>
+            Read more about Graylog pipeline rules in the <DocumentationLink page={DocsHelper.PAGES.PIPELINE_RULES}
+                                                                             text="documentation" />.
+          </span>
+
+          <span>
+            <LinkContainer to="/system/pipelines/rules">
+              <Button bsStyle="info">Manage rules</Button>
+            </LinkContainer>
+            &nbsp;
+            <LinkContainer to="/system/pipelines/overview">
+              <Button bsStyle="info">Manage pipelines</Button>
+            </LinkContainer>
+          </span>
+        </PageHeader>
+
+        <Row className="content">
+          <Col md={6}>
+            <RuleForm rule={this.props.rule} create={this.props.create} onSave={this.props.onSave}
+                      validateRule={this.props.validateRule} history={this.props.history} />
+          </Col>
+          <Col md={5} mdOffset={1}>
+            <RuleHelper />
+          </Col>
+        </Row>
+      </div>
+    );
+  },
+});
+
+export default Rule;

--- a/src/web/rules/RuleDetailsPage.jsx
+++ b/src/web/rules/RuleDetailsPage.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import Reflux from 'reflux';
+
+import { Spinner } from 'components/common';
+
+import Rule from './Rule';
+import RulesStore from './RulesStore';
+import RulesActions from './RulesActions';
+
+function filterRules(state) {
+  return state.rules ? state.rules.filter(r => r.id === this.props.params.ruleId)[0] : undefined;
+}
+
+const RuleDetailsPage = React.createClass({
+  propTypes: {
+    params: React.PropTypes.object.isRequired,
+    history: React.PropTypes.object.isRequired,
+  },
+
+  mixins: [Reflux.connectFilter(RulesStore, 'rule', filterRules)],
+
+  componentDidMount() {
+    if (this.props.params.ruleId !== 'new') {
+      RulesActions.get(this.props.params.ruleId);
+    }
+  },
+
+  _save(rule, callback) {
+    let promise;
+    if (rule.id) {
+      promise = RulesActions.update.triggerPromise(rule);
+    } else {
+      promise = RulesActions.save.triggerPromise(rule);
+    }
+    promise.then(() => callback());
+  },
+
+  _validateRule(rule, setErrorsCb) {
+    RulesActions.parse(rule, setErrorsCb);
+  },
+
+  _isLoading() {
+    return this.props.params.ruleId !== 'new' && !this.state.rule;
+  },
+
+  render() {
+    if (this._isLoading()) {
+      return <Spinner />;
+    }
+
+    return (
+      <Rule rule={this.state.rule} create={this.props.params.ruleId === 'new'} onSave={this._save}
+            validateRule={this._validateRule} history={this.props.history} />
+    );
+  },
+});
+
+export default RuleDetailsPage;

--- a/src/web/rules/RuleForm.jsx
+++ b/src/web/rules/RuleForm.jsx
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 
-import { Row, Col } from 'react-bootstrap';
 import { Input } from 'react-bootstrap';
 
 import AceEditor from 'react-ace';
@@ -12,7 +11,6 @@ import 'brace/theme/chrome';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 
 const RuleForm = React.createClass({
-  parseTimer: undefined,
   propTypes: {
     rule: PropTypes.object,
     create: React.PropTypes.bool,
@@ -28,7 +26,7 @@ const RuleForm = React.createClass({
         description: '',
         source: '',
       },
-    }
+    };
   },
 
   getInitialState() {
@@ -39,11 +37,11 @@ const RuleForm = React.createClass({
         id: rule.id,
         title: rule.title,
         description: rule.description,
-        source: rule.source
+        source: rule.source,
       },
       editor: undefined,
       parseErrors: [],
-    }
+    };
   },
 
   componentWillUnmount() {
@@ -53,6 +51,8 @@ const RuleForm = React.createClass({
     }
   },
 
+  parseTimer: undefined,
+
   openModal() {
     this.refs.modal.open();
   },
@@ -60,13 +60,13 @@ const RuleForm = React.createClass({
   _updateEditor() {
     const session = this.state.editor.session;
     const annotations = this.state.parseErrors.map(e => {
-      return {row: e.line - 1, column: e.position_in_line - 1, text: e.reason, type: "error"}
+      return { row: e.line - 1, column: e.position_in_line - 1, text: e.reason, type: 'error' };
     });
     session.setAnnotations(annotations);
   },
 
   _setParseErrors(errors) {
-    this.setState({parseErrors: errors}, this._updateEditor);
+    this.setState({ parseErrors: errors }, this._updateEditor);
   },
 
   _onSourceChange(value) {
@@ -76,7 +76,7 @@ const RuleForm = React.createClass({
     }
     const rule = this.state.rule;
     rule.source = value;
-    this.setState({rule: rule});
+    this.setState({ rule });
 
     if (this.props.validateRule) {
       // have the caller validate the rule after typing stopped for a while. usually this will mean send to server to parse
@@ -87,17 +87,17 @@ const RuleForm = React.createClass({
   _onDescriptionChange(event) {
     const rule = this.state.rule;
     rule.description = event.target.value;
-    this.setState({rule: rule});
+    this.setState({ rule });
   },
 
   _onTitleChange(event) {
     const rule = this.state.rule;
     rule.title = event.target.value;
-    this.setState({rule: rule});
+    this.setState({ rule });
   },
 
   _onLoad(editor) {
-    this.setState({editor: editor});
+    this.setState({ editor });
   },
 
   _getId(prefixIdName) {
@@ -111,7 +111,7 @@ const RuleForm = React.createClass({
   _saved() {
     this._closeModal();
     if (this.props.create) {
-      this.setState({rule: {}});
+      this.setState({ rule: {} });
     }
   },
 
@@ -144,18 +144,18 @@ const RuleForm = React.createClass({
                    label="Description (optional)"
                    onChange={this._onDescriptionChange}
                    autoFocus
-                   value={this.state.rule.description}/>
+                   value={this.state.rule.description} />
 
             <label>Rule source</label>
-            <div style={{border: "1px solid lightgray", borderRadius: 5}}>
+            <div style={{border: '1px solid lightgray', borderRadius: 5}}>
               <AceEditor
                 mode="text"
                 theme="chrome"
-                name={"source" + (this.props.create ? "-create" : "-edit")}
+                name={`source${this.props.create ? '-create' : '-edit'}`}
                 fontSize={11}
                 height="14em"
                 width="100%"
-                editorProps={{ $blockScrolling: "Infinity"}}
+                editorProps={{ $blockScrolling: 'Infinity'}}
                 value={this.state.rule.source}
                 onLoad={this._onLoad}
                 onChange={this._onSourceChange}

--- a/src/web/rules/RuleForm.jsx
+++ b/src/web/rules/RuleForm.jsx
@@ -121,6 +121,10 @@ const RuleForm = React.createClass({
     return (
       <form ref="form" onSubmit={this._submit}>
         <fieldset>
+          <Input type="static"
+                 label="Title"
+                 value="You can set the rule title in the rule source. See the quick reference for more information." />
+
           <Input type="textarea"
                  id={this._getId('description')}
                  label="Description"
@@ -129,7 +133,7 @@ const RuleForm = React.createClass({
                  help="Rule description (optional)."
                  value={this.state.rule.description} />
 
-          <Input label="Rule source" help="Rule source, see help for more information.">
+          <Input label="Rule source" help="Rule source, see quick reference for more information.">
             <div style={{ border: '1px solid lightgray', borderRadius: 5 }}>
               <AceEditor
                 mode="text"

--- a/src/web/rules/RuleForm.jsx
+++ b/src/web/rules/RuleForm.jsx
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
-
-import { Input } from 'react-bootstrap';
+import { Row, Col, Button, Input } from 'react-bootstrap';
 
 import AceEditor from 'react-ace';
 import brace from 'brace';
@@ -8,14 +7,13 @@ import brace from 'brace';
 import 'brace/mode/text';
 import 'brace/theme/chrome';
 
-import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
-
 const RuleForm = React.createClass({
   propTypes: {
     rule: PropTypes.object,
     create: React.PropTypes.bool,
-    save: React.PropTypes.func.isRequired,
+    onSave: React.PropTypes.func.isRequired,
     validateRule: React.PropTypes.func.isRequired,
+    history: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {
@@ -52,10 +50,6 @@ const RuleForm = React.createClass({
   },
 
   parseTimer: undefined,
-
-  openModal() {
-    this.refs.modal.open();
-  },
 
   _updateEditor() {
     const session = this.state.editor.session;
@@ -104,50 +98,39 @@ const RuleForm = React.createClass({
     return this.state.name !== undefined ? prefixIdName + this.state.name : prefixIdName;
   },
 
-  _closeModal() {
-    this.refs.modal.close();
+  _goBack() {
+    this.props.history.goBack();
   },
 
   _saved() {
-    this._closeModal();
-    if (this.props.create) {
-      this.setState({ rule: {} });
-    }
+    this.props.history.pushState(null, '/system/pipelines/rules');
   },
 
   _save() {
     if (this.state.parseErrors.length === 0) {
-      this.props.save(this.state.rule, this._saved);
+      this.props.onSave(this.state.rule, this._saved);
     }
   },
 
-  render() {
-    let triggerButtonContent;
-    if (this.props.create) {
-      triggerButtonContent = 'Add new rule';
-    } else {
-      triggerButtonContent = <span>Edit</span>;
-    }
-    return (
-      <span>
-        <button onClick={this.openModal}
-                className={this.props.create ? 'btn btn-success' : 'btn btn-info btn-xs'}>
-          {triggerButtonContent}
-        </button>
-        <BootstrapModalForm ref="modal"
-                            title={`${this.props.create ? 'Add new' : 'Edit'} rule ${this.state.rule.title}`}
-                            onSubmitForm={this._save}
-                            submitButtonText="Save">
-          <fieldset>
-            <Input type="textarea"
-                   id={this._getId('description')}
-                   label="Description (optional)"
-                   onChange={this._onDescriptionChange}
-                   autoFocus
-                   value={this.state.rule.description} />
+  _submit(event) {
+    event.preventDefault();
+    this._save();
+  },
 
-            <label>Rule source</label>
-            <div style={{border: '1px solid lightgray', borderRadius: 5}}>
+  render() {
+    return (
+      <form ref="form" onSubmit={this._submit}>
+        <fieldset>
+          <Input type="textarea"
+                 id={this._getId('description')}
+                 label="Description"
+                 onChange={this._onDescriptionChange}
+                 autoFocus
+                 help="Rule description (optional)."
+                 value={this.state.rule.description} />
+
+          <Input label="Rule source" help="Rule source, see help for more information.">
+            <div style={{ border: '1px solid lightgray', borderRadius: 5 }}>
               <AceEditor
                 mode="text"
                 theme="chrome"
@@ -161,9 +144,18 @@ const RuleForm = React.createClass({
                 onChange={this._onSourceChange}
               />
             </div>
-          </fieldset>
-        </BootstrapModalForm>
-      </span>
+          </Input>
+        </fieldset>
+
+        <Row>
+          <Col md={12}>
+            <div className="form-group">
+              <Button type="submit" bsStyle="primary" style={{ marginRight: 10 }}>Save</Button>
+              <Button type="button" onClick={this._goBack}>Cancel</Button>
+            </div>
+          </Col>
+        </Row>
+      </form>
     );
   },
 });

--- a/src/web/rules/RuleHelper.jsx
+++ b/src/web/rules/RuleHelper.jsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { Row, Col, Panel, Tabs, Tab } from 'react-bootstrap';
+
+import DocumentationLink from 'components/support/DocumentationLink';
+
+import DocsHelper from 'util/DocsHelper';
+
+const RuleHelper = React.createClass({
+  ruleTemplate: `rule "function howto"
+when
+  has_field("transaction_date")
+then
+  // the following date format assumes there's no time zone in the string
+  let new_date = parse_date(tostring($message.transaction_date), "yyyy-MM-dd HH:mm:ss");
+  set_field("transaction_year", new_date.year);
+end`,
+
+  render() {
+    return (
+      <Panel header="Rules quick reference">
+        <Row className="row-sm">
+          <Col md={12}>
+            <p style={{ marginTop: 5 }}>
+              Read the <DocumentationLink page={DocsHelper.PAGES.PIPELINE_RULES}
+                                                 text="full documentation" />{' '}
+              to gain a better understanding of how Graylog pipeline rules work.
+            </p>
+          </Col>
+        </Row>
+        <Row className="row-sm">
+          <Col md={12}>
+            <Tabs defaultActiveKey={1} animation={false}>
+              <Tab eventKey={1} title="Example">
+                <pre style={{ marginTop: 10, whiteSpace: 'pre-wrap' }}>
+                  {this.ruleTemplate}
+                </pre>
+              </Tab>
+              <Tab eventKey={2} title="Functions">
+                <div className="table-responsive" style={{ marginTop: 10 }}>
+                  <table className="table">
+                    <thead>
+                    <tr>
+                      <th>Function</th>
+                      <th>Description</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                      <td><code>tobool(any)</code></td>
+                      <td>Converts the single parameter to a boolean value using its string value.</td>
+                    </tr>
+                    <tr>
+                      <td><code>todouble(any, [default: double])</code></td>
+                      <td>Converts the first parameter to a double floating point value.</td>
+                    </tr>
+                    <tr>
+                      <td><code>tolong(any, [default: long])</code></td>
+                      <td>Converts the first parameter to a long integer value.</td>
+                    </tr>
+                    <tr>
+                      <td><code>tostring(any, [default: string])</code></td>
+                      <td>Converts the first parameter to its string representation.</td>
+                    </tr>
+                    <tr>
+                      <td><code>capitalize(value: string)</code></td>
+                      <td>Capitalizes a String changing the first letter to title case.</td>
+                    </tr>
+                    <tr>
+                      <td><code>uppercase(value: string, [locale: string])</code></td>
+                      <td>Converts a String to upper case.</td>
+                    </tr>
+                    <tr>
+                      <td><code>lowercase(value: string, [locale: string])</code></td>
+                      <td>Converts a String to lower case.</td>
+                    </tr>
+                    <tr>
+                      <td><code>contains(value: string, search: string, [ignore_case: boolean])</code></td>
+                      <td>Checks if a string contains another string.</td>
+                    </tr>
+                    <tr>
+                      <td><code>substring(value: string, start: long, [end: long])</code></td>
+                      <td>Returns a substring of <code><span>value</span></code> with the given start and end offsets.
+                      </td>
+                    </tr>
+                    <tr>
+                      <td><code>regex(pattern: string, value: string, [group_names: array[string])</code></td>
+                      <td>Match a regular expression against a string, with matcher groups.</td>
+                    </tr>
+                    <tr>
+                      <td><code>parse_date(value: string, pattern: string, [timezone: string])</code></td>
+                      <td>Parses a date and time from the given string, according to a strict pattern.</td>
+                    </tr>
+                    <tr>
+                      <td><code>flex_parse_date(value: string, [default: DateTime], [timezone: string])</code></td>
+                      <td>Attempts to parse a date and time using the Natty date parser.</td>
+                    </tr>
+                    <tr>
+                      <td><code>format_date(value: DateTime, format: string, [timezone: string])</code></td>
+                      <td>Formats a date and time according to a given formatter pattern.</td>
+                    </tr>
+                    <tr>
+                      <td><code>parse_json(value: string)</code></td>
+                      <td>Parse a string into a JSON tree.</td>
+                    </tr>
+                    <tr>
+                      <td><code>toip(ip: string)</code></td>
+                      <td>Converts the given string to an IP object.</td>
+                    </tr>
+                    <tr>
+                      <td><code>cidr_match(cidr: string, ip: IpAddress)</code></td>
+                      <td>Checks whether the given IP matches a CIDR pattern.</td>
+                    </tr>
+                    <tr>
+                      <td><code>from_input(id: string | name: string)</code></td>
+                      <td>Checks whether the current message was received by the given input.</td>
+                    </tr>
+                    <tr>
+                      <td><code>route_to_stream(id: string | name: string, [message: Message])</code></td>
+                      <td>Assigns the current message to the specified stream.</td>
+                    </tr>
+                    <tr>
+                      <td><code>drop_message(message: Message)</code></td>
+                      <td>This currently processed message will be removed from the processing pipeline after the rule
+                        finishes.
+                      </td>
+                    </tr>
+                    <tr>
+                      <td><code>has_field(field: string, [message: Message])</code></td>
+                      <td>Checks whether the currently processed message contains the named field.</td>
+                    </tr>
+                    <tr>
+                      <td><code>remove_field(field: string, [message: Message])</code></td>
+                      <td>Removes the named field from the currently processed message.</td>
+                    </tr>
+                    <tr>
+                      <td><code>set_field(field: string, value: any, [message: Message])</code></td>
+                      <td>Sets the name field to the given value in the currently processed message.</td>
+                    </tr>
+                    <tr>
+                      <td><code>set_fields(fields: Map&lt;string, any&gt;, [message: Message])</code></td>
+                      <td>Sets multiple fields to the given values in the currently processed message.</td>
+                    </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <p>See all functions in the <DocumentationLink page={DocsHelper.PAGES.PIPELINE_FUNCTIONS}
+                                                               text="documentation" />.</p>
+              </Tab>
+            </Tabs>
+          </Col>
+        </Row>
+      </Panel>
+    );
+  },
+});
+
+export default RuleHelper;

--- a/src/web/rules/RuleList.jsx
+++ b/src/web/rules/RuleList.jsx
@@ -36,7 +36,11 @@ const RuleList = React.createClass({
 
     return (
       <tr key={rule.title}>
-        <td>{rule.title}</td>
+        <td>
+          <LinkContainer to={`/system/pipelines/rules/${rule.id}`}>
+            <a>{rule.title}</a>
+          </LinkContainer>
+        </td>
         <td className="limited">{rule.description}</td>
         <td className="limited"><Timestamp dateTime={rule.created_at} relative /></td>
         <td className="limited"><Timestamp dateTime={rule.modified_at} relative /></td>

--- a/src/web/rules/RuleList.jsx
+++ b/src/web/rules/RuleList.jsx
@@ -2,8 +2,8 @@ import React, { PropTypes } from 'react';
 import { DataTable, Timestamp } from 'components/common';
 
 import { Button } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
-import RuleForm from './RuleForm';
 import RulesActions from './RulesActions';
 
 const RuleList = React.createClass({
@@ -11,38 +11,36 @@ const RuleList = React.createClass({
     rules: PropTypes.array.isRequired,
   },
 
-  _save(rule, callback) {
-    if (rule.id) {
-      RulesActions.update(rule);
-    } else {
-      RulesActions.save(rule);
-    }
-    callback();
-  },
-
   _delete(rule) {
-    if (window.confirm(`Do you really want to delete rule "${rule.title}"?`)) {
-      RulesActions.delete(rule.id);
-    }
-  },
-
-  _validateRule(rule, setErrorsCb) {
-    RulesActions.parse(rule, setErrorsCb);
+    return () => {
+      if (window.confirm(`Do you really want to delete rule "${rule.title}"?`)) {
+        RulesActions.delete(rule.id);
+      }
+    };
   },
 
   _headerCellFormatter(header) {
     return <th>{header}</th>;
   },
+
   _ruleInfoFormatter(rule) {
     const actions = [
-      <Button key="delete" bsStyle="primary" bsSize="xsmall" onClick={() => this._delete(rule)} title="Delete rule">Delete</Button>,
+      <Button key="delete" bsStyle="primary" bsSize="xsmall" onClick={this._delete(rule)} title="Delete rule">
+        Delete
+      </Button>,
       <span key="space">&nbsp;</span>,
-      <RuleForm key="edit" rule={rule} validateRule={this._validateRule} save={this._save} />,
+      <LinkContainer key="edit" to={`/system/pipelines/rules/${rule.id}`}>
+        <Button bsStyle="info" bsSize="xsmall">Edit</Button>
+      </LinkContainer>,
     ];
 
     return (
       <tr key={rule.title}>
-        <td>{rule.title}</td>
+        <td>
+          <LinkContainer to={`/system/pipelines/rules/${rule.id}`}>
+            <a>{rule.title}</a>
+          </LinkContainer>
+        </td>
         <td className="limited">{rule.description}</td>
         <td className="limited"><Timestamp dateTime={rule.created_at} relative /></td>
         <td className="limited"><Timestamp dateTime={rule.modified_at} relative /></td>
@@ -67,15 +65,14 @@ const RuleList = React.createClass({
                    filterLabel="Filter Rules"
                    filterKeys={filterKeys}>
           <div className="pull-right">
-            <RuleForm create
-                      save={this._save}
-                      validateRule={this._validateRule}
-            />
+            <LinkContainer to="/system/pipelines/rules/new">
+              <Button bsStyle="success">Create Rule</Button>
+            </LinkContainer>
           </div>
         </DataTable>
       </div>
     );
-  }
+  },
 });
 
 export default RuleList;

--- a/src/web/rules/RuleList.jsx
+++ b/src/web/rules/RuleList.jsx
@@ -14,7 +14,7 @@ const RuleList = React.createClass({
   _delete(rule) {
     return () => {
       if (window.confirm(`Do you really want to delete rule "${rule.title}"?`)) {
-        RulesActions.delete(rule.id);
+        RulesActions.delete(rule);
       }
     };
   },

--- a/src/web/rules/RuleList.jsx
+++ b/src/web/rules/RuleList.jsx
@@ -36,11 +36,7 @@ const RuleList = React.createClass({
 
     return (
       <tr key={rule.title}>
-        <td>
-          <LinkContainer to={`/system/pipelines/rules/${rule.id}`}>
-            <a>{rule.title}</a>
-          </LinkContainer>
-        </td>
+        <td>{rule.title}</td>
         <td className="limited">{rule.description}</td>
         <td className="limited"><Timestamp dateTime={rule.created_at} relative /></td>
         <td className="limited"><Timestamp dateTime={rule.modified_at} relative /></td>

--- a/src/web/rules/RulesActions.jsx
+++ b/src/web/rules/RulesActions.jsx
@@ -1,12 +1,13 @@
 import Reflux from 'reflux';
 
 const RulesActions = Reflux.createActions({
-  'delete': {asyncResult: true},
-  'list': {asyncResult: true},
-  'save': {asyncResult: true},
-  'update': {asyncResult: true},
-  'parse': {asyncResult: true},
-  'multiple': {asyncResult: true},
+  delete: { asyncResult: true },
+  list: { asyncResult: true },
+  get: { asyncResult: true },
+  save: { asyncResult: true },
+  update: { asyncResult: true },
+  parse: { asyncResult: true },
+  multiple: { asyncResult: true },
 });
 
 export default RulesActions;

--- a/src/web/rules/RulesStore.js
+++ b/src/web/rules/RulesStore.js
@@ -13,7 +13,21 @@ const RulesStore = Reflux.createStore({
   rules: undefined,
 
   getInitialState() {
-    return {rules: this.rules};
+    return { rules: this.rules };
+  },
+
+  _updateRulesState(rule) {
+    if (!this.rules) {
+      this.rules = [rule];
+    } else {
+      const doesRuleExist = this.rules.some(r => r.id === rule.id);
+      if (doesRuleExist) {
+        this.rules = this.rules.map(r => r.id === rule.id ? rule : r);
+      } else {
+        this.rules.push(rule);
+      }
+    }
+    this.trigger({ rules: this.rules });
   },
 
   list() {
@@ -25,47 +39,64 @@ const RulesStore = Reflux.createStore({
     const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/rule');
     return fetch('GET', url).then((response) => {
       this.rules = response;
-      this.trigger({rules: response});
+      this.trigger({ rules: response });
     }, failCallback);
+  },
+
+  get(ruleId) {
+    const failCallback = (error) => {
+      UserNotification.error(`Fetching rule "${ruleId}" failed with status: ${error.message}`,
+        `Could not retrieve processing rule "${ruleId}"`);
+    };
+
+    const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/rule/${ruleId}`);
+    const promise = fetch('GET', url);
+    promise.then(this._updateRulesState, failCallback);
+
+    return promise;
   },
 
   save(ruleSource) {
     const failCallback = (error) => {
-      UserNotification.error('Saving rule failed with status: ' + error.message,
-        'Could not save processing rule');
+      UserNotification.error(`Saving rule "${ruleSource.title}" failed with status: ${error.message}`,
+        `Could not save processing rule "${ruleSource.title}"`);
     };
-    const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/rule');
+    const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/rule`);
     const rule = {
       title: ruleSource.title,
       description: ruleSource.description,
       source: ruleSource.source,
     };
-    return fetch('POST', url, rule).then((response) => {
-      if (this.rules === undefined) {
-        this.rules = [response];
-      } else {
-        this.rules.push(response);
-      }
-      this.trigger({rules: this.rules});
+    const promise = fetch('POST', url, rule);
+    promise.then((response) => {
+      this._updateRulesState(response);
+      UserNotification.success(`Rule "${response.title}" created successfully`);
     }, failCallback);
+
+    RulesActions.save.promise(promise);
+    return promise;
   },
 
   update(ruleSource) {
     const failCallback = (error) => {
-      UserNotification.error('Updating rule failed with status: ' + error.message,
-        'Could not update processing rule');
+      UserNotification.error(`Updating rule "${ruleSource.title}" failed with status: ${error.message}`,
+        `Could not update processing rule "${ruleSource.title}"`);
     };
-    const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/rule/' + ruleSource.id);
+    const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/rule/${ruleSource.id}`);
     const rule = {
       id: ruleSource.id,
       title: ruleSource.title,
       description: ruleSource.description,
       source: ruleSource.source,
     };
-    return fetch('PUT', url, rule).then((response) => {
-      this.rules = this.rules.map((e) => e.id === response.id ? response : e);
-      this.trigger({rules: this.rules});
+    const promise = fetch('PUT', url, rule);
+    promise.then((response) => {
+      this._updateRulesState(response);
+      UserNotification.success(`Rule "${response.title}" updated successfully`);
     }, failCallback);
+
+    RulesActions.update.promise(promise);
+    return promise;
   },
   delete(ruleId) {
     const failCallback = (error) => {
@@ -75,7 +106,7 @@ const RulesStore = Reflux.createStore({
     const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/rule/' + ruleId);
     return fetch('DELETE', url).then(() => {
       this.rules = this.rules.filter((el) => el.id !== ruleId);
-      this.trigger({rules: this.rules});
+      this.trigger({ rules: this.rules });
     }, failCallback);
   },
   parse(ruleSource, callback) {
@@ -101,7 +132,7 @@ const RulesStore = Reflux.createStore({
   },
   multiple(ruleNames, callback) {
     const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/rule/multiple');
-    const promise = fetch('POST', url, {rules: ruleNames});
+    const promise = fetch('POST', url, { rules: ruleNames });
     promise.then(callback);
 
     return promise;

--- a/src/web/rules/RulesStore.js
+++ b/src/web/rules/RulesStore.js
@@ -98,15 +98,16 @@ const RulesStore = Reflux.createStore({
     RulesActions.update.promise(promise);
     return promise;
   },
-  delete(ruleId) {
+  delete(rule) {
     const failCallback = (error) => {
-      UserNotification.error('Updating rule failed with status: ' + error.message,
-        'Could not update processing rule');
+      UserNotification.error(`Deleting rule "${rule.title}" failed with status: ${error.message}`,
+        `Could not delete processing rule "${rule.title}"`);
     };
-    const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/rule/' + ruleId);
+    const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/rule/${rule.id}`);
     return fetch('DELETE', url).then(() => {
-      this.rules = this.rules.filter((el) => el.id !== ruleId);
+      this.rules = this.rules.filter((el) => el.id !== rule.id);
       this.trigger({ rules: this.rules });
+      UserNotification.success(`Rule "${rule.title}" was deleted successfully`);
     }, failCallback);
   },
   parse(ruleSource, callback) {


### PR DESCRIPTION
Editing rules in a modal is far from optimal, so I decided to move the form to its own page. This gives us some advantages:

- Display rule examples and functions to help users writing their own rules
- Link to the details page from anywhere, as we can point to this page with the ID, not needing to load the rules and create modals for each one of them
- The editor errors will show up in the right place

What do you think? Yay or nay?