### PR TITLE
Simplify pipeline management

### DIFF
--- a/src/web/pipelines/NewPipeline.jsx
+++ b/src/web/pipelines/NewPipeline.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Row, Col } from 'react-bootstrap';
+
+import PipelineDetails from './PipelineDetails';
+
+const NewPipeline = React.createClass({
+  propTypes: {
+    onChange: React.PropTypes.func.isRequired,
+    history: React.PropTypes.object.isRequired,
+  },
+
+  _onChange(newPipeline) {
+    this.props.onChange(newPipeline, this._goToPipeline);
+  },
+
+  _goToPipeline(pipeline) {
+    this.props.history.pushState(null, `/system/pipelines/${pipeline.id}`);
+  },
+
+  _goBack() {
+    this.props.history.goBack();
+  },
+
+  render() {
+    return (
+      <Row>
+        <Col md={6}>
+          <p>
+            Give a name and description to the new pipeline. You can add stages to it when you save the changes.
+          </p>
+          <PipelineDetails create onChange={this._onChange} onCancel={this._goBack} />
+        </Col>
+      </Row>
+    );
+  },
+});
+
+export default NewPipeline;

--- a/src/web/pipelines/Pipeline.jsx
+++ b/src/web/pipelines/Pipeline.jsx
@@ -1,9 +1,10 @@
 import React, { PropTypes } from 'react';
 import { Row, Col } from 'react-bootstrap';
 
-import { EntityList, Timestamp } from 'components/common';
+import { EntityList } from 'components/common';
 import Stage from './Stage';
 import StageForm from './StageForm';
+import PipelineDetails from './PipelineDetails';
 
 import {} from './Pipeline.css';
 
@@ -11,6 +12,7 @@ const Pipeline = React.createClass({
   propTypes: {
     pipeline: PropTypes.object.isRequired,
     onStagesChange: PropTypes.func.isRequired,
+    onPipelineChange: PropTypes.func.isRequired,
   },
 
   _saveStage(stage, callback) {
@@ -52,20 +54,17 @@ const Pipeline = React.createClass({
 
     return (
       <div>
-        <Row>
+        <PipelineDetails pipeline={this.props.pipeline} onChange={this.props.onPipelineChange} />
+        <Row className="row-sm" style={{ marginTop: 10 }}>
           <Col md={12}>
             <div className="pull-right">
               <StageForm create save={this._saveStage} />
             </div>
-            <h2>Information</h2>
-            <dl className="dl-horizontal pipeline-dl">
-              <dt>Description</dt>
-              <dd>{pipeline.description}</dd>
-              <dt>Created</dt>
-              <dd><Timestamp dateTime={pipeline.created_at} relative /></dd>
-              <dt>Last modified</dt>
-              <dd><Timestamp dateTime={pipeline.modified_at} relative /></dd>
-            </dl>
+            <h2>Pipeline Stages</h2>
+            <p style={{ marginTop: 5 }}>
+              Stages are groups of conditions and actions which need to run in order, and provide the necessary{' '}
+              control flow to decide whether or not to run the rest of a pipeline.
+            </p>
           </Col>
         </Row>
         <EntityList bsNoItemsStyle="info" noItemsText="There are no rules on this stage." items={formattedStages} />

--- a/src/web/pipelines/PipelineDetails.jsx
+++ b/src/web/pipelines/PipelineDetails.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Row, Col } from 'react-bootstrap';
+
+import { Timestamp } from 'components/common';
+import PipelineForm from './PipelineForm';
+
+const PipelineDetails = React.createClass({
+  propTypes: {
+    pipeline: React.PropTypes.object,
+    create: React.PropTypes.bool,
+    onChange: React.PropTypes.func.isRequired,
+  },
+
+  render() {
+    if (this.props.create) {
+      return <PipelineForm create save={this.props.onChange} modal={false} />;
+    }
+
+    const pipeline = this.props.pipeline;
+    return (
+      <div>
+        <Row>
+          <Col md={12}>
+            <div className="pull-right">
+              <PipelineForm pipeline={pipeline} save={this.props.onChange} />
+            </div>
+            <h2>Details</h2>
+            <dl className="dl-horizontal pipeline-dl" style={{ marginTop: 10 }}>
+              <dt>Title</dt>
+              <dd>{pipeline.title}</dd>
+              <dt>Description</dt>
+              <dd>{pipeline.description}</dd>
+              <dt>Created</dt>
+              <dd><Timestamp dateTime={pipeline.created_at} relative /></dd>
+              <dt>Last modified</dt>
+              <dd><Timestamp dateTime={pipeline.modified_at} relative /></dd>
+            </dl>
+          </Col>
+        </Row>
+        <hr />
+      </div>
+    );
+  },
+});
+
+export default PipelineDetails;

--- a/src/web/pipelines/PipelineForm.jsx
+++ b/src/web/pipelines/PipelineForm.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Input, Button } from 'react-bootstrap';
+import { Row, Col, Input, Button } from 'react-bootstrap';
 
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import ObjectUtils from 'util/ObjectUtils';
@@ -9,12 +9,15 @@ const PipelineForm = React.createClass({
   propTypes: {
     pipeline: React.PropTypes.object,
     create: React.PropTypes.bool,
+    modal: React.PropTypes.bool,
     save: React.PropTypes.func.isRequired,
     validatePipeline: React.PropTypes.func.isRequired,
+    onCancel: React.PropTypes.func,
   },
 
   getDefaultProps() {
     return {
+      modal: true,
       pipeline: {
         id: undefined,
         title: '',
@@ -52,13 +55,20 @@ const PipelineForm = React.createClass({
   },
 
   _saved() {
-    this._closeModal();
+    if (this.props.modal) {
+      this._closeModal();
+    }
+
     if (this.props.create) {
       this.setState(this.getInitialState());
     }
   },
 
-  _save() {
+  _save(event) {
+    if (event) {
+      event.preventDefault();
+    }
+
     this.props.save(this.state.pipeline, this._saved);
   },
 
@@ -67,41 +77,58 @@ const PipelineForm = React.createClass({
     if (this.props.create) {
       triggerButtonContent = 'Add new pipeline';
     } else {
-      triggerButtonContent = <span>Edit</span>;
+      triggerButtonContent = 'Edit pipeline details';
+    }
+
+    const content = (
+      <fieldset>
+        <Input type="text"
+               id="title"
+               name="title"
+               label="Title"
+               autoFocus
+               required
+               onChange={this._onChange}
+               help="Pipeline name."
+               value={this.state.pipeline.title} />
+
+        <Input type="text"
+               id="description"
+               name="description"
+               label="Description"
+               onChange={this._onChange}
+               help="Pipeline description."
+               value={this.state.pipeline.description} />
+      </fieldset>
+    );
+
+    if (this.props.modal) {
+      return (
+        <span>
+          <Button onClick={this.openModal}
+                  bsStyle="success">
+            {triggerButtonContent}
+          </Button>
+          <BootstrapModalForm ref="modal"
+                              title={`${this.props.create ? 'Add new' : 'Edit'} pipeline ${this.state.pipeline.title}`}
+                              onSubmitForm={this._save}
+                              submitButtonText="Save">
+            {content}
+          </BootstrapModalForm>
+        </span>
+      );
     }
 
     return (
-      <span>
-        <Button onClick={this.openModal}
-                bsStyle={this.props.create ? 'success' : 'info'}
-                bsSize={this.props.create ? null : 'xsmall'}>
-          {triggerButtonContent}
-        </Button>
-        <BootstrapModalForm ref="modal"
-                            title={`${this.props.create ? 'Add new' : 'Edit'} pipeline ${this.state.pipeline.title}`}
-                            onSubmitForm={this._save}
-                            submitButtonText="Save">
-          <fieldset>
-            <Input type="text"
-                   id="title"
-                   name="title"
-                   label="Title"
-                   autoFocus
-                   required
-                   onChange={this._onChange}
-                   help="Pipeline name."
-                   value={this.state.pipeline.title} />
-
-            <Input type="text"
-                   id="description"
-                   name="description"
-                   label="Description"
-                   onChange={this._onChange}
-                   help="Pipeline description."
-                   value={this.state.pipeline.description} />
-          </fieldset>
-        </BootstrapModalForm>
-      </span>
+      <form onSubmit={this._save}>
+        {content}
+        <Row>
+          <Col md={12}>
+            <Button type="submit" bsStyle="primary" style={{ marginRight: 10 }}>Save</Button>
+            <Button type="button" onClick={this.props.onCancel}>Cancel</Button>
+          </Col>
+        </Row>
+      </form>
     );
   },
 });

--- a/src/web/pipelines/PipelinesStore.js
+++ b/src/web/pipelines/PipelinesStore.js
@@ -65,12 +65,15 @@ const PipelinesStore = Reflux.createStore({
       description: pipelineSource.description,
       source: pipelineSource.source,
     };
-    return fetch('POST', url, pipeline).then(
+    const promise = fetch('POST', url, pipeline);
+    promise.then(
       response => {
         this._updatePipelinesState(response);
         UserNotification.success(`Pipeline "${pipeline.title}" created successfully`);
       },
       failCallback);
+
+    PipelinesActions.save.promise(promise);
   },
 
   update(pipelineSource) {
@@ -85,12 +88,15 @@ const PipelinesStore = Reflux.createStore({
       description: pipelineSource.description,
       source: pipelineSource.source,
     };
-    return fetch('PUT', url, pipeline).then(
+    const promise = fetch('PUT', url, pipeline);
+    promise.then(
       response => {
         this._updatePipelinesState(response);
         UserNotification.success(`Pipeline "${pipeline.title}" updated successfully`);
       },
       failCallback);
+
+    PipelinesActions.update.promise(promise);
   },
   delete(pipelineId) {
     const failCallback = (error) => {

--- a/src/web/pipelines/ProcessingTimelineComponent.jsx
+++ b/src/web/pipelines/ProcessingTimelineComponent.jsx
@@ -5,13 +5,9 @@ import { LinkContainer } from 'react-router-bootstrap';
 import naturalSort from 'javascript-natural-sort';
 
 import { DataTable, Spinner } from 'components/common';
-import PipelineForm from './PipelineForm';
 
 import PipelinesActions from 'pipelines/PipelinesActions';
 import PipelinesStore from 'pipelines/PipelinesStore';
-
-import ObjectUtils from 'util/ObjectUtils';
-import SourceGenerator from 'logic/SourceGenerator';
 
 import {} from './ProcessingTimelineComponent.css';
 
@@ -71,21 +67,12 @@ const ProcessingTimelineComponent = React.createClass({
         <td>
           <Button bsStyle="primary" bsSize="xsmall" onClick={this._deletePipeline(pipeline)}>Delete</Button>
           &nbsp;
-          <PipelineForm pipeline={pipeline} save={this._savePipeline}/>
+          <LinkContainer to={`/system/pipelines/${pipeline.id}`}>
+            <Button bsStyle="info" bsSize="xsmall">Edit</Button>
+          </LinkContainer>
         </td>
       </tr>
     );
-  },
-
-  _savePipeline(pipeline, callback) {
-    const requestPipeline = ObjectUtils.clone(pipeline);
-    requestPipeline.source = SourceGenerator.generatePipeline(pipeline);
-    if (requestPipeline.id) {
-      PipelinesActions.update(requestPipeline);
-    } else {
-      PipelinesActions.save(requestPipeline);
-    }
-    callback();
   },
 
   _deletePipeline(pipeline) {
@@ -101,10 +88,18 @@ const ProcessingTimelineComponent = React.createClass({
       return <Spinner />;
     }
 
+    const addNewPipelineButton = (
+      <div className="text-right">
+        <LinkContainer to="/system/pipelines/new">
+          <Button bsStyle="success">Add new pipeline</Button>
+        </LinkContainer>
+      </div>
+    );
+
     if (this.state.pipelines.length === 0) {
       return (
         <div>
-          <div className="text-right"><PipelineForm create save={this._savePipeline} /></div>
+          {addNewPipelineButton}
           <Alert>
             There are no pipelines configured in your system. Create one to start processing your messages.
           </Alert>
@@ -117,7 +112,7 @@ const ProcessingTimelineComponent = React.createClass({
     const headers = ['Pipeline', 'ProcessingTimeline', 'Actions'];
     return (
       <div>
-        <div className="pull-right"><PipelineForm create save={this._savePipeline}/></div>
+        {addNewPipelineButton}
         <DataTable id="processing-timeline"
                    className="table-hover"
                    headers={headers}


### PR DESCRIPTION
Before, creating and editing pipelines had two steps:

1. Modify pipeline title and description (using a modal in the pipeline list page)
2. Modify stages in the pipeline details page

These changes move the title and description form into the pipeline details page, so all steps to create and edit a pipeline are in the same place.