### PR TITLE
Make function names more consistent

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/BooleanConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/BooleanConversion.java
@@ -26,7 +26,7 @@ import static com.google.common.collect.ImmutableList.of;
 import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
 
 public class BooleanConversion extends AbstractFunction<Boolean> {
-    public static final String NAME = "tobool";
+    public static final String NAME = "to_bool";
 
     private final ParameterDescriptor<Object, Boolean> valueParam;
 

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/DoubleConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/DoubleConversion.java
@@ -30,7 +30,7 @@ import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescr
 
 public class DoubleConversion extends AbstractFunction<Double> {
 
-    public static final String NAME = "todouble";
+    public static final String NAME = "to_double";
 
     private static final String VALUE = "value";
     private static final String DEFAULT = "default";

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/LongConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/LongConversion.java
@@ -30,7 +30,7 @@ import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescr
 
 public class LongConversion extends AbstractFunction<Long> {
 
-    public static final String NAME = "tolong";
+    public static final String NAME = "to_long";
 
     private static final String VALUE = "value";
     private static final String DEFAULT = "default";

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/StringConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/StringConversion.java
@@ -33,7 +33,7 @@ import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescr
 
 public class StringConversion extends AbstractFunction<String> {
 
-    public static final String NAME = "tostring";
+    public static final String NAME = "to_string";
 
     // this is per-thread to save an expensive concurrent hashmap access
     private final ThreadLocal<LinkedHashMap<Class<?>, Class<?>>> declaringClassCache;

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddressConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddressConversion.java
@@ -31,7 +31,7 @@ import static com.google.common.collect.ImmutableList.of;
 
 public class IpAddressConversion extends AbstractFunction<IpAddress> {
 
-    public static final String NAME = "toip";
+    public static final String NAME = "to_ip";
     private final ParameterDescriptor<Object, Object> ipParam;
     private final ParameterDescriptor<String, String> defaultParam;
 
@@ -55,7 +55,7 @@ public class IpAddressConversion extends AbstractFunction<IpAddress> {
             try {
                 return new IpAddress(InetAddresses.forString(defaultValue.get()));
             } catch (IllegalFormatException e1) {
-                log.warn("Parameter `default` for toip() is not a valid IP address: {}", defaultValue.get());
+                log.warn("Parameter `default` for to_ip() is not a valid IP address: {}", defaultValue.get());
                 throw e1;
             }
         }

--- a/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -285,7 +285,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
         assertThat(context).isNotNull();
         assertThat(context.hasEvaluationErrors()).isTrue();
-        assertThat(Iterables.getLast(context.evaluationErrors()).toString()).isEqualTo("In call to function 'toip' at 5:28 an exception was thrown: 'null' is not an IP string literal.");
+        assertThat(Iterables.getLast(context.evaluationErrors()).toString()).isEqualTo("In call to function 'to_ip' at 5:28 an exception was thrown: 'null' is not an IP string literal.");
     }
 
     @Test

--- a/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -56,7 +56,7 @@ public class PipelineInterpreterTest {
                                "title",
                                "description",
                                "rule \"creates message\"\n" +
-                                       "when tostring($message.message) == \"original message\"\n" +
+                                       "when to_string($message.message) == \"original message\"\n" +
                                        "then\n" +
                                        "  create_message(\"derived message\");\n" +
                                        "end",

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dates.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dates.txt
@@ -11,5 +11,5 @@ then
     trigger_test();
     let date = parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ");
     set_field("year", date.year);
-    set_field("timezone", tostring(date.zone));
+    set_field("timezone", to_string(date.zone));
 end

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/evalError.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/evalError.txt
@@ -2,5 +2,5 @@ rule "trigger null"
 when
   true
 then
-  set_field("this_is_null", toip($message.does_not_exist));
+  set_field("this_is_null", to_ip($message.does_not_exist));
 end

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/evalErrorSuppressed.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/evalErrorSuppressed.txt
@@ -1,6 +1,6 @@
 rule "suppressing exceptions/nulls"
 when
-    is_null(toip($message.does_not_exist)) && is_not_null($message.this_field_was_set)
+    is_null(to_ip($message.does_not_exist)) && is_not_null($message.this_field_was_set)
 then
     trigger_test();
 end

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/ipMatching.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/ipMatching.txt
@@ -1,9 +1,9 @@
 rule "ip handling"
 when
-    cidr_match("192.0.0.0/8", toip("192.168.1.50")) &&
-    ! cidr_match("191.0.0.0/8", toip("192.168.1.50"))
+    cidr_match("192.0.0.0/8", to_ip("192.168.1.50")) &&
+    ! cidr_match("191.0.0.0/8", to_ip("192.168.1.50"))
 then
-    set_field("ip_anon", tostring(toip($message.ip).anonymized));
-    set_field("ipv6_anon", tostring(toip("2001:db8::1").anonymized));
+    set_field("ip_anon", to_string(to_ip($message.ip).anonymized));
+    set_field("ipv6_anon", to_string(to_ip("2001:db8::1").anonymized));
     trigger_test();
 end

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/jsonpath.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/jsonpath.txt
@@ -1,7 +1,7 @@
 rule "jsonpath"
 when true
 then
-  let x = parse_json(tostring($message.message));
+  let x = parse_json(to_string($message.message));
   let new_fields = select_jsonpath(x,
             { author_first: "$['store']['book'][0]['author']",
               author_last: "$['store']['book'][-1:]['author']"

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/parser/messageRef.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/parser/messageRef.txt
@@ -1,5 +1,5 @@
 rule "message field ref"
-when tolong(value: $message.responseCode, default: 200) >= 500
+when to_long(value: $message.responseCode, default: 200) >= 500
 then
     set_field(field: "response_category", value: "server_error");
 end

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/parser/messageRefQuotedField.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/parser/messageRefQuotedField.txt
@@ -1,5 +1,5 @@
 rule "test"
-when tostring($message.`@specialfieldname`, "empty") == "string"
+when to_string($message.`@specialfieldname`, "empty") == "string"
 then
     trigger_test();
 end

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/parser/typedFieldAccess.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/parser/typedFieldAccess.txt
@@ -1,6 +1,6 @@
 rule "typed field access"
 when
-    tolong(customObject("1").id, 0) < 2
+    to_long(customObject("1").id, 0) < 2
 then
     trigger_test();
 end

--- a/src/web/rules/RuleHelper.jsx
+++ b/src/web/rules/RuleHelper.jsx
@@ -11,7 +11,7 @@ when
   has_field("transaction_date")
 then
   // the following date format assumes there's no time zone in the string
-  let new_date = parse_date(tostring($message.transaction_date), "yyyy-MM-dd HH:mm:ss");
+  let new_date = parse_date(to_string($message.transaction_date), "yyyy-MM-dd HH:mm:ss");
   set_field("transaction_year", new_date.year);
 end`,
 
@@ -46,19 +46,19 @@ end`,
                     </thead>
                     <tbody>
                     <tr>
-                      <td><code>tobool(any)</code></td>
+                      <td><code>to_bool(any)</code></td>
                       <td>Converts the single parameter to a boolean value using its string value.</td>
                     </tr>
                     <tr>
-                      <td><code>todouble(any, [default: double])</code></td>
+                      <td><code>to_double(any, [default: double])</code></td>
                       <td>Converts the first parameter to a double floating point value.</td>
                     </tr>
                     <tr>
-                      <td><code>tolong(any, [default: long])</code></td>
+                      <td><code>to_long(any, [default: long])</code></td>
                       <td>Converts the first parameter to a long integer value.</td>
                     </tr>
                     <tr>
-                      <td><code>tostring(any, [default: string])</code></td>
+                      <td><code>to_string(any, [default: string])</code></td>
                       <td>Converts the first parameter to its string representation.</td>
                     </tr>
                     <tr>
@@ -103,7 +103,7 @@ end`,
                       <td>Parse a string into a JSON tree.</td>
                     </tr>
                     <tr>
-                      <td><code>toip(ip: string)</code></td>
+                      <td><code>to_ip(ip: string)</code></td>
                       <td>Converts the given string to an IP object.</td>
                     </tr>
                     <tr>


### PR DESCRIPTION
Function names should be lowercase and words be separated by an underscore, e. g. `to_string` instead of `tostring`.