### PR TITLE
Add additional hash functions

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -28,7 +28,11 @@ import org.graylog.plugins.pipelineprocessor.functions.dates.FlexParseDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FormatDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.Now;
 import org.graylog.plugins.pipelineprocessor.functions.dates.ParseDate;
+import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32;
+import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32C;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.MD5;
+import org.graylog.plugins.pipelineprocessor.functions.hashing.Murmur3_128;
+import org.graylog.plugins.pipelineprocessor.functions.hashing.Murmur3_32;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.SHA1;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.SHA256;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.SHA512;
@@ -100,7 +104,11 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(FormatDate.NAME, FormatDate.class);
 
         // hash digest
+        addMessageProcessorFunction(CRC32.NAME, CRC32.class);
+        addMessageProcessorFunction(CRC32C.NAME, CRC32C.class);
         addMessageProcessorFunction(MD5.NAME, MD5.class);
+        addMessageProcessorFunction(Murmur3_32.NAME, Murmur3_32.class);
+        addMessageProcessorFunction(Murmur3_128.NAME, Murmur3_128.class);
         addMessageProcessorFunction(SHA1.NAME, SHA1.class);
         addMessageProcessorFunction(SHA256.NAME, SHA256.class);
         addMessageProcessorFunction(SHA512.NAME, SHA512.class);

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/hashing/CRC32.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/hashing/CRC32.java
@@ -1,0 +1,36 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.hashing;
+
+import com.google.common.hash.Hashing;
+
+import java.nio.charset.StandardCharsets;
+
+public class CRC32 extends SingleArgStringFunction {
+
+    public static final String NAME = "crc32";
+
+    @Override
+    protected String getDigest(String value) {
+        return Hashing.crc32().hashString(value, StandardCharsets.UTF_8).toString();
+    }
+
+    @Override
+    protected String getName() {
+        return NAME;
+    }
+}

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/hashing/CRC32C.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/hashing/CRC32C.java
@@ -1,0 +1,36 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.hashing;
+
+import com.google.common.hash.Hashing;
+
+import java.nio.charset.StandardCharsets;
+
+public class CRC32C extends SingleArgStringFunction {
+
+    public static final String NAME = "crc32c";
+
+    @Override
+    protected String getDigest(String value) {
+        return Hashing.crc32c().hashString(value, StandardCharsets.UTF_8).toString();
+    }
+
+    @Override
+    protected String getName() {
+        return NAME;
+    }
+}

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/hashing/Murmur3_128.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/hashing/Murmur3_128.java
@@ -1,0 +1,36 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.hashing;
+
+import com.google.common.hash.Hashing;
+
+import java.nio.charset.StandardCharsets;
+
+public class Murmur3_128 extends SingleArgStringFunction {
+
+    public static final String NAME = "murmur3_128";
+
+    @Override
+    protected String getDigest(String value) {
+        return Hashing.murmur3_128().hashString(value, StandardCharsets.UTF_8).toString();
+    }
+
+    @Override
+    protected String getName() {
+        return NAME;
+    }
+}

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/hashing/Murmur3_32.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/hashing/Murmur3_32.java
@@ -1,0 +1,36 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.hashing;
+
+import com.google.common.hash.Hashing;
+
+import java.nio.charset.StandardCharsets;
+
+public class Murmur3_32 extends SingleArgStringFunction {
+
+    public static final String NAME = "murmur3_32";
+
+    @Override
+    protected String getDigest(String value) {
+        return Hashing.murmur3_32().hashString(value, StandardCharsets.UTF_8).toString();
+    }
+
+    @Override
+    protected String getName() {
+        return NAME;
+    }
+}

--- a/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -31,7 +31,11 @@ import org.graylog.plugins.pipelineprocessor.functions.dates.FlexParseDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FormatDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.Now;
 import org.graylog.plugins.pipelineprocessor.functions.dates.ParseDate;
+import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32;
+import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32C;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.MD5;
+import org.graylog.plugins.pipelineprocessor.functions.hashing.Murmur3_128;
+import org.graylog.plugins.pipelineprocessor.functions.hashing.Murmur3_32;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.SHA1;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.SHA256;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.SHA512;
@@ -136,7 +140,11 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(ParseDate.NAME, new ParseDate());
         functions.put(FormatDate.NAME, new FormatDate());
 
+        functions.put(CRC32.NAME, new CRC32());
+        functions.put(CRC32C.NAME, new CRC32C());
         functions.put(MD5.NAME, new MD5());
+        functions.put(Murmur3_32.NAME, new Murmur3_32());
+        functions.put(Murmur3_128.NAME, new Murmur3_128());
         functions.put(SHA1.NAME, new SHA1());
         functions.put(SHA256.NAME, new SHA256());
         functions.put(SHA512.NAME, new SHA512());

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/digests.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/digests.txt
@@ -1,6 +1,10 @@
 rule "digests"
 when
+    crc32("graylog") == "e3018c57" &&
+    crc32c("graylog") == "82390e89" &&
     md5("graylog") == "6f9efb466e043b9f3635827ce446e13c" &&
+    murmur3_32("graylog") == "67285534" &&
+    murmur3_128("graylog") == "945d5b1aaa8fdfe9b880b31e814972b3" &&
     sha1("graylog") == "6d88bccf40bf65b911fe79d78c7af98e382f0c1a" &&
     sha256("graylog") == "4bbdd5a829dba09d7a7ff4c1367be7d36a017b4267d728d31bd264f63debeaa6" &&
     sha512("graylog") == "f6cb3a96450fb9c9174299a651333c926cd67b6f5c25d8daeede1589ffa006f4dd31da4f0625b7f281051a34c8352b3a9c1a9babf90020360e911a380b5c3f4f"


### PR DESCRIPTION
This PR adds support for additional (fast) hash functions supported by Google Guava: CRC32, CRC32C, MurmurHash3 (32-bit), and MurmurHash3 (128-bit).