### PR TITLE
add interpreter counter metrics

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/ast/Rule.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/ast/Rule.java
@@ -22,11 +22,15 @@ import org.graylog.plugins.pipelineprocessor.ast.expressions.BooleanExpression;
 import org.graylog.plugins.pipelineprocessor.ast.expressions.LogicalExpression;
 import org.graylog.plugins.pipelineprocessor.ast.statements.Statement;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 
 @AutoValue
 public abstract class Rule {
+
+    @Nullable
+    public abstract String id();
 
     public abstract String name();
 
@@ -38,12 +42,19 @@ public abstract class Rule {
         return new AutoValue_Rule.Builder();
     }
 
+    public abstract Builder toBuilder();
+
+    public Rule withId(String id) {
+        return toBuilder().id(id).build();
+    }
+
     public static Rule alwaysFalse(String name) {
         return builder().name(name).when(new BooleanExpression(new CommonToken(-1), false)).then(Collections.emptyList()).build();
     }
     @AutoValue.Builder
     public abstract static class Builder {
 
+        public abstract Builder id(String id);
         public abstract Builder name(String name);
         public abstract Builder when(LogicalExpression condition);
         public abstract Builder then(Collection<Statement> actions);

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
@@ -101,7 +101,12 @@ public class PipelineRuleParser {
     private static final Logger log = LoggerFactory.getLogger(PipelineRuleParser.class);
     public static final ParseTreeWalker WALKER = ParseTreeWalker.DEFAULT;
 
+
     public Rule parseRule(String rule, boolean silent) throws ParseException {
+        return parseRule(null, rule, silent);
+    }
+
+    public Rule parseRule(String id, String rule, boolean silent) throws ParseException {
         final ParseContext parseContext = new ParseContext(silent);
         final SyntaxErrorListener errorListener = new SyntaxErrorListener(parseContext);
 
@@ -128,7 +133,8 @@ public class PipelineRuleParser {
         WALKER.walk(new RuleTypeChecker(parseContext), ruleDeclaration);
 
         if (parseContext.getErrors().isEmpty()) {
-            return parseContext.getRules().get(0);
+            final Rule parsedRule = parseContext.getRules().get(0);
+            return parsedRule.withId(id);
         }
         throw new ParseException(parseContext.getErrors());
     }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -367,7 +367,7 @@ public class PipelineInterpreter implements MessageProcessor {
     public void handleRuleChanges(RulesChangedEvent event) {
         event.deletedRuleIds().forEach(id -> {
             log.debug("Invalidated rule {}", id);
-            metricRegistry.removeMatching((name, metric) -> name.startsWith(name(Pipeline.class, id)));
+            metricRegistry.removeMatching((name, metric) -> name.startsWith(name(Rule.class, id)));
         });
         event.updatedRuleIds().forEach(id -> {
             log.debug("Refreshing rule {}", id);

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -80,6 +80,7 @@ public class PipelineInterpreter implements MessageProcessor {
     private final PipelineStreamConnectionsService pipelineStreamConnectionsService;
     private final PipelineRuleParser pipelineRuleParser;
     private final Journal journal;
+    private final MetricRegistry metricRegistry;
     private final ScheduledExecutorService scheduler;
     private final Meter filteredOutMessages;
 
@@ -101,6 +102,7 @@ public class PipelineInterpreter implements MessageProcessor {
         this.pipelineRuleParser = pipelineRuleParser;
 
         this.journal = journal;
+        this.metricRegistry = metricRegistry;
         this.scheduler = scheduler;
         this.filteredOutMessages = metricRegistry.meter(name(ProcessBufferProcessor.class, "filteredOutMessages"));
 
@@ -117,7 +119,7 @@ public class PipelineInterpreter implements MessageProcessor {
         for (RuleDao ruleDao : ruleService.loadAll()) {
             Rule rule;
             try {
-                rule = pipelineRuleParser.parseRule(ruleDao.source(), false);
+                rule = pipelineRuleParser.parseRule(ruleDao.id(), ruleDao.source(), false);
             } catch (ParseException e) {
                 rule = Rule.alwaysFalse("Failed to parse rule: " + ruleDao.id());
             }
@@ -206,9 +208,11 @@ public class PipelineInterpreter implements MessageProcessor {
                     } else {
                         // get the default stream pipeline connections for this message
                         pipelinesToRun = streamConnection.get("default");
-                        log.debug("[{}] running default stream pipelines: [{}]",
-                                 msgId,
-                                 pipelinesToRun.stream().map(Pipeline::name).toArray());
+                        if (log.isDebugEnabled()) {
+                            log.debug("[{}] running default stream pipelines: [{}]",
+                                      msgId,
+                                      pipelinesToRun.stream().map(Pipeline::name).toArray());
+                        }
                     }
                 } else {
                     // 2. if a message-stream combination has already been processed (is in the set), skip that execution
@@ -222,8 +226,11 @@ public class PipelineInterpreter implements MessageProcessor {
                     log.debug("[{}] running pipelines {} for streams {}", msgId, pipelinesToRun, streamsIds);
                 }
 
+                // record execution of pipeline in metrics
+                pipelinesToRun.stream().forEach(pipeline -> metricRegistry.counter(name(Pipeline.class, pipeline.id(), "executed")).inc());
+
                 final StageIterator stages = new StageIterator(pipelinesToRun);
-                final Set<Pipeline> pipelinesToProceedWith = Sets.newHashSet();
+                final Set<Pipeline> pipelinesToSkip = Sets.newHashSet();
 
                 // iterate through all stages for all matching pipelines, per "stage slice" instead of per pipeline.
                 // pipeline execution ordering is not guaranteed
@@ -232,13 +239,13 @@ public class PipelineInterpreter implements MessageProcessor {
                     for (Tuple2<Stage, Pipeline> pair : stageSet) {
                         final Stage stage = pair.v1();
                         final Pipeline pipeline = pair.v2();
-                        if (!pipelinesToProceedWith.isEmpty() &&
-                                !pipelinesToProceedWith.contains(pipeline)) {
+                        if (pipelinesToSkip.contains(pipeline)) {
                             log.debug("[{}] previous stage result prevents further processing of pipeline `{}`",
                                      msgId,
                                      pipeline.name());
                             continue;
                         }
+                        metricRegistry.counter(name(Pipeline.class, pipeline.id(), "stage", String.valueOf(stage.stage()), "executed")).inc();
                         log.debug("[{}] evaluating rule conditions in stage {}: match {}",
                                  msgId,
                                  stage.stage(),
@@ -249,8 +256,12 @@ public class PipelineInterpreter implements MessageProcessor {
 
                         // 3. iterate over all the stages in these pipelines and execute them in order
                         final ArrayList<Rule> rulesToRun = Lists.newArrayListWithCapacity(stage.getRules().size());
+                        boolean anyRulesMatched = false;
                         for (Rule rule : stage.getRules()) {
                             if (rule.when().evaluateBool(context)) {
+                                anyRulesMatched = true;
+                                countRuleExecution(rule, pipeline, stage, "matched");
+
                                 if (context.hasEvaluationErrors()) {
                                     final EvaluationContext.EvalError lastError = Iterables.getLast(context.evaluationErrors());
                                     appendProcessingError(rule, message, lastError.toString());
@@ -261,10 +272,12 @@ public class PipelineInterpreter implements MessageProcessor {
                                 log.debug("[{}] rule `{}` matches, scheduling to run", msgId, rule.name());
                                 rulesToRun.add(rule);
                             } else {
+                                countRuleExecution(rule, pipeline, stage, "not-matched");
                                 log.debug("[{}] rule `{}` does not match", msgId, rule.name());
                             }
                         }
                         for (Rule rule : rulesToRun) {
+                            countRuleExecution(rule, pipeline, stage, "executed");
                             log.debug("[{}] rule `{}` matched running actions", msgId, rule.name());
                             for (Statement statement : rule.then()) {
                                 statement.evaluate(context);
@@ -274,6 +287,7 @@ public class PipelineInterpreter implements MessageProcessor {
                                     appendProcessingError(rule, message, lastError.toString());
                                     log.debug("Encountered evaluation error, skipping rest of the rule: {}",
                                               lastError);
+                                    countRuleExecution(rule, pipeline, stage, "failed");
                                     break;
                                 }
                             }
@@ -284,10 +298,14 @@ public class PipelineInterpreter implements MessageProcessor {
                         // any rule could match, but at least one had to,
                         // record that it is ok to proceed with the pipeline
                         if ((stage.matchAll() && (rulesToRun.size() == stage.getRules().size()))
-                                || (rulesToRun.size() > 0)) {
-                            log.debug("[{}] stage for pipeline `{}` required match: {}, ok to proceed with next stage",
-                                     msgId, pipeline.name(), stage.matchAll() ? "all" : "either");
-                            pipelinesToProceedWith.add(pipeline);
+                                || (rulesToRun.size() > 0 && anyRulesMatched)) {
+                            log.debug("[{}] stage {} for pipeline `{}` required match: {}, ok to proceed with next stage",
+                                     msgId, stage.stage(), pipeline.name(), stage.matchAll() ? "all" : "either");
+                        } else {
+                            // no longer execute stages from this pipeline, the guard prevents it
+                            log.debug("[{}] stage {} for pipeline `{}` required match: {}, NOT ok to proceed with next stage",
+                                      msgId, stage.stage(), pipeline.name(), stage.matchAll() ? "all" : "either");
+                            pipelinesToSkip.add(pipeline);
                         }
 
                         // 4. after each complete stage run, merge the processing changes, stages are isolated from each other
@@ -331,6 +349,11 @@ public class PipelineInterpreter implements MessageProcessor {
         return new MessageCollection(fullyProcessed);
     }
 
+    private void countRuleExecution(Rule rule, Pipeline pipeline, Stage stage, String type) {
+        metricRegistry.counter(name(Rule.class, rule.id(), type)).inc();
+        metricRegistry.counter(name(Rule.class, rule.id(), pipeline.id(), String.valueOf(stage.stage()), type)).inc();
+    }
+
     private void appendProcessingError(Rule rule, Message message, String errorString) {
         final String msg = "For rule '" + rule.name() + "': " + errorString;
         if (message.hasField(GL2_PROCESSING_ERROR)) {
@@ -344,6 +367,7 @@ public class PipelineInterpreter implements MessageProcessor {
     public void handleRuleChanges(RulesChangedEvent event) {
         event.deletedRuleIds().forEach(id -> {
             log.debug("Invalidated rule {}", id);
+            metricRegistry.removeMatching((name, metric) -> name.startsWith(name(Pipeline.class, id)));
         });
         event.updatedRuleIds().forEach(id -> {
             log.debug("Refreshing rule {}", id);
@@ -355,6 +379,7 @@ public class PipelineInterpreter implements MessageProcessor {
     public void handlePipelineChanges(PipelinesChangedEvent event) {
         event.deletedPipelineIds().forEach(id -> {
             log.debug("Invalidated pipeline {}", id);
+            metricRegistry.removeMatching((name, metric) -> name.startsWith(name(Pipeline.class, id)));
         });
         event.updatedPipelineIds().forEach(id -> {
             log.debug("Refreshing pipeline {}", id);

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -276,6 +276,7 @@ public class PipelineInterpreter implements MessageProcessor {
                                 log.debug("[{}] rule `{}` does not match", msgId, rule.name());
                             }
                         }
+                        RULES:
                         for (Rule rule : rulesToRun) {
                             countRuleExecution(rule, pipeline, stage, "executed");
                             log.debug("[{}] rule `{}` matched running actions", msgId, rule.name());
@@ -288,7 +289,7 @@ public class PipelineInterpreter implements MessageProcessor {
                                     log.debug("Encountered evaluation error, skipping rest of the rule: {}",
                                               lastError);
                                     countRuleExecution(rule, pipeline, stage, "failed");
-                                    break;
+                                    break RULES;
                                 }
                             }
                         }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/rest/RuleResource.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/rest/RuleResource.java
@@ -78,7 +78,7 @@ public class RuleResource extends RestResource implements PluginRestResource {
     public RuleSource createFromParser(@ApiParam(name = "rule", required = true) @NotNull RuleSource ruleSource) throws ParseException {
         final Rule rule;
         try {
-            rule = pipelineRuleParser.parseRule(ruleSource.source(), false);
+            rule = pipelineRuleParser.parseRule(ruleSource.id(), ruleSource.source(), false);
         } catch (ParseException e) {
             throw new BadRequestException(Response.status(Response.Status.BAD_REQUEST).entity(e.getErrors()).build());
         }
@@ -103,7 +103,7 @@ public class RuleResource extends RestResource implements PluginRestResource {
         final Rule rule;
         try {
             // be silent about parse errors here, many requests will result in invalid syntax
-            rule = pipelineRuleParser.parseRule(ruleSource.source(), true);
+            rule = pipelineRuleParser.parseRule(ruleSource.id(), ruleSource.source(), true);
         } catch (ParseException e) {
             throw new BadRequestException(Response.status(Response.Status.BAD_REQUEST).entity(e.getErrors()).build());
         }
@@ -152,7 +152,7 @@ public class RuleResource extends RestResource implements PluginRestResource {
         final RuleDao ruleDao = ruleService.load(id);
         final Rule rule;
         try {
-            rule = pipelineRuleParser.parseRule(update.source(), false);
+            rule = pipelineRuleParser.parseRule(id, update.source(), false);
         } catch (ParseException e) {
             throw new BadRequestException(Response.status(Response.Status.BAD_REQUEST).entity(e.getErrors()).build());
         }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/rest/RuleSource.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/rest/RuleSource.java
@@ -90,7 +90,7 @@ public abstract class RuleSource {
     public static RuleSource fromDao(PipelineRuleParser parser, RuleDao dao) {
         Set<ParseError> errors = null;
         try {
-            parser.parseRule(dao.source(), false);
+            parser.parseRule(dao.id(), dao.source(), false);
 
         } catch (ParseException e) {
             errors = e.getErrors();

--- a/src/web/pipelines/Pipeline.css
+++ b/src/web/pipelines/Pipeline.css
@@ -4,7 +4,7 @@
 
 dl.pipeline-dl > dt {
     text-align: left;
-    width: 90px;
+    width: 140px;
 }
 
 dl.pipeline-dl > dt:after {

--- a/src/web/pipelines/Pipeline.jsx
+++ b/src/web/pipelines/Pipeline.jsx
@@ -48,7 +48,7 @@ const Pipeline = React.createClass({
 
   _formatStage(stage, maxStage) {
     return (
-      <Stage key={`stage-${stage.stage}`} stage={stage} isLastStage={stage.stage === maxStage}
+      <Stage key={`stage-${stage.stage}`} pipeline={this.props.pipeline} stage={stage} isLastStage={stage.stage === maxStage}
              onUpdate={this._updateStage(stage)} onDelete={this._deleteStage(stage)} />
     );
   },

--- a/src/web/pipelines/PipelineDetails.jsx
+++ b/src/web/pipelines/PipelineDetails.jsx
@@ -4,6 +4,8 @@ import { Row, Col } from 'react-bootstrap';
 import { Timestamp } from 'components/common';
 import PipelineForm from './PipelineForm';
 
+import { MetricContainer, CounterRate } from 'components/metrics';
+
 const PipelineDetails = React.createClass({
   propTypes: {
     pipeline: React.PropTypes.object,
@@ -34,6 +36,12 @@ const PipelineDetails = React.createClass({
               <dd><Timestamp dateTime={pipeline.created_at} relative /></dd>
               <dt>Last modified</dt>
               <dd><Timestamp dateTime={pipeline.modified_at} relative /></dd>
+              <dt>Current throughput</dt>
+              <dd>
+                <MetricContainer name={`org.graylog.plugins.pipelineprocessor.ast.Pipeline.${pipeline.id}.executed`}>
+                  <CounterRate suffix="msg/s" />
+                </MetricContainer>
+              </dd>
             </dl>
           </Col>
         </Row>

--- a/src/web/pipelines/ProcessingTimelineComponent.jsx
+++ b/src/web/pipelines/ProcessingTimelineComponent.jsx
@@ -5,6 +5,7 @@ import { LinkContainer } from 'react-router-bootstrap';
 import naturalSort from 'javascript-natural-sort';
 
 import { DataTable, Spinner } from 'components/common';
+import { MetricContainer, CounterRate } from 'components/metrics';
 
 import PipelinesActions from 'pipelines/PipelinesActions';
 import PipelinesStore from 'pipelines/PipelinesStore';
@@ -67,6 +68,10 @@ const ProcessingTimelineComponent = React.createClass({
         <td className="pipeline-name">
           <LinkContainer to={`/system/pipelines/${pipeline.id}`}><a>{pipeline.title}</a></LinkContainer><br />
           {pipeline.description}
+          <br />
+          <MetricContainer name={`org.graylog.plugins.pipelineprocessor.ast.Pipeline.${pipeline.id}.executed`}>
+            <CounterRate prefix="Throughput:" suffix="msg/s" />
+          </MetricContainer>
         </td>
         <td>{this._formatStages(pipeline, pipeline.stages)}</td>
         <td>
@@ -114,7 +119,7 @@ const ProcessingTimelineComponent = React.createClass({
 
     this.usedStages = this._calculateUsedStages(this.state.pipelines);
 
-    const headers = ['Pipeline', 'ProcessingTimeline', 'Actions'];
+    const headers = ['Pipeline', 'Processing Timeline', 'Actions'];
     return (
       <div>
         {addNewPipelineButton}

--- a/src/web/rules/RuleList.jsx
+++ b/src/web/rules/RuleList.jsx
@@ -6,6 +6,8 @@ import { LinkContainer } from 'react-router-bootstrap';
 
 import RulesActions from './RulesActions';
 
+import { MetricContainer, CounterRate } from 'components/metrics';
+
 const RuleList = React.createClass({
   propTypes: {
     rules: PropTypes.array.isRequired,
@@ -44,13 +46,23 @@ const RuleList = React.createClass({
         <td className="limited">{rule.description}</td>
         <td className="limited"><Timestamp dateTime={rule.created_at} relative /></td>
         <td className="limited"><Timestamp dateTime={rule.modified_at} relative /></td>
+        <td>
+          <MetricContainer name={`org.graylog.plugins.pipelineprocessor.ast.Rule.${rule.id}.executed`} zeroOnMissing>
+            <CounterRate suffix="msg/s" />
+          </MetricContainer>
+        </td>
+        <td>
+          <MetricContainer name={`org.graylog.plugins.pipelineprocessor.ast.Rule.${rule.id}.failed`}>
+            <CounterRate showTotal suffix="errors/s" hideOnMissing />
+          </MetricContainer>
+        </td>
         <td className="actions">{actions}</td>
       </tr>
     );
   },
   render() {
     const filterKeys = ['title', 'description'];
-    const headers = ['Title', 'Description', 'Created', 'Last modified', 'Actions'];
+    const headers = ['Title', 'Description', 'Created', 'Last modified', 'Throughput', 'Errors', 'Actions'];
 
     return (
       <div>


### PR DESCRIPTION
use CounterRate to display per second rates in the pipeline pages:
 - throughput and error rates
 - per pipeline
 - per stage
 - per rule (globally and per pipeline-stage)