### PR TITLE
add URL parse function

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/ast/functions/FunctionDescriptor.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/ast/functions/FunctionDescriptor.java
@@ -55,6 +55,9 @@ public abstract class FunctionDescriptor<T> {
         public abstract Builder<T> name(String name);
         public abstract Builder<T> pure(boolean pure);
         public abstract Builder<T> returnType(Class<? extends T> type);
+        public Builder<T> params(ParameterDescriptor... params) {
+            return params(ImmutableList.<ParameterDescriptor>builder().add(params).build());
+        }
         public abstract Builder<T> params(ImmutableList<ParameterDescriptor> params);
         public abstract Builder<T> paramMap(ImmutableMap<String, ParameterDescriptor> map);
         public abstract ImmutableList<ParameterDescriptor> params();

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -56,6 +56,7 @@ import org.graylog.plugins.pipelineprocessor.functions.strings.Substring;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Swapcase;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Uncapitalize;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Uppercase;
+import org.graylog.plugins.pipelineprocessor.functions.urls.UrlConversion;
 import org.graylog2.plugin.PluginModule;
 
 public class ProcessorFunctionsModule extends PluginModule {
@@ -120,6 +121,9 @@ public class ProcessorFunctionsModule extends PluginModule {
         // null support
         addMessageProcessorFunction(IsNull.NAME, IsNull.class);
         addMessageProcessorFunction(IsNotNull.NAME, IsNotNull.class);
+
+        // URL parsing
+        addMessageProcessorFunction(UrlConversion.NAME, UrlConversion.class);
     }
 
     protected void addMessageProcessorFunction(String name, Class<? extends Function<?>> functionClass) {

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/urls/URL.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/urls/URL.java
@@ -1,0 +1,114 @@
+package org.graylog.plugins.pipelineprocessor.functions.urls;
+
+import com.google.common.collect.Maps;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.util.Map;
+
+/**
+ * This class simply delegates the safe methods to the java.net.URL.
+ *
+ * Specifically we want to disallow called java.net.URL#getContent from a rule.
+ */
+public class URL {
+
+    private final java.net.URL url;
+    private Map<String, String> queryMap;
+
+    public URL(java.net.URL url) {
+        this.url = url;
+    }
+
+    public URL(String urlString) throws MalformedURLException {
+        url = URI.create(urlString).toURL();
+    }
+
+    public String getQuery() {
+        return url.getQuery();
+    }
+
+    public Map<String, String> getQueryParams() {
+        if (queryMap == null) {
+            queryMap = splitQuery(getQuery());
+        }
+        return queryMap;
+    }
+
+    private static Map<String, String> splitQuery(String query) {
+        final Map<String, String> nameValues = Maps.newHashMap();
+        final String[] kvPairs = query.split("&");
+        for (String pair : kvPairs) {
+            try {
+                final int idx = pair.indexOf("=");
+                final String key = idx > 0 ? URLDecoder.decode(pair.substring(0, idx), "UTF-8") : pair;
+                final String value = idx > 0 && pair.length() > idx + 1 ? URLDecoder.decode(pair.substring(idx + 1),
+                                                                                            "UTF-8") : null;
+                if (nameValues.containsKey(key)) {
+                    nameValues.put(key, nameValues.get(key) + "," + value); // TODO well, this is also crappy
+                } else {
+                    nameValues.put(key, value);
+                }
+            } catch (UnsupportedEncodingException ignored) {
+                // ignored because UTF-8 is a required encoding
+            }
+        }
+        return nameValues;
+    }
+
+    public String getUserInfo() {
+        return url.getUserInfo();
+    }
+
+    public String getHost() {
+        return url.getHost();
+    }
+
+    public String getPath() {
+        return url.getPath();
+    }
+
+    public String getFile() {
+        return url.getFile();
+    }
+
+    public String getProtocol() {
+        return url.getProtocol();
+    }
+
+    public int getDefaultPort() {
+        return url.getDefaultPort();
+    }
+
+    /**
+     * alias for #getRef, fragment is more commonly used
+     */
+    public String getFragment() {
+        return url.getRef();
+    }
+
+    public String getRef() {
+        return url.getRef();
+    }
+
+    public String getAuthority() {
+        return url.getAuthority();
+    }
+
+    public int getPort() {
+        return url.getPort();
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @Override
+    public boolean equals(Object obj) {
+        return url.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return url.hashCode();
+    }
+}

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/urls/URL.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/urls/URL.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.pipelineprocessor.functions.urls;
 
 import com.google.common.collect.Maps;

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/urls/UrlConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/urls/UrlConversion.java
@@ -1,0 +1,50 @@
+package org.graylog.plugins.pipelineprocessor.functions.urls;
+
+import com.google.common.base.Throwables;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.net.MalformedURLException;
+import java.util.Optional;
+
+public class UrlConversion extends AbstractFunction<URL> {
+
+    public static final String NAME = "to_url";
+
+    private final ParameterDescriptor<Object, Object> urlParam = ParameterDescriptor.object("url").build();
+    private final ParameterDescriptor<String, String> defaultParam = ParameterDescriptor.string("default").optional().build();
+
+    @Override
+    public URL evaluate(FunctionArgs args, EvaluationContext context) {
+        final String urlString = String.valueOf(urlParam.required(args, context));
+        try {
+            return new URL(urlString);
+        } catch (IllegalArgumentException | MalformedURLException e) {
+            log.debug("Unable to parse URL for string {}", urlString, e);
+
+            final Optional<String> defaultUrl = defaultParam.optional(args, context);
+            if (!defaultUrl.isPresent()) {
+                return null;
+            }
+            try {
+                return new URL(defaultUrl.get());
+            } catch (IllegalArgumentException | MalformedURLException e1) {
+                log.warn("Parameter `default` for to_url() is not a valid URL: {}", defaultUrl.get());
+                throw Throwables.propagate(e1);
+            }
+        }
+    }
+
+    @Override
+    public FunctionDescriptor<URL> descriptor() {
+        return FunctionDescriptor.<URL>builder()
+                .name(NAME)
+                .returnType(URL.class)
+                .params(urlParam,
+                        defaultParam)
+                .build();
+    }
+}

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/urls/UrlConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/urls/UrlConversion.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.pipelineprocessor.functions.urls;
 
 import com.google.common.base.Throwables;

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/urls.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/urls.txt
@@ -1,0 +1,21 @@
+rule "urls"
+when
+    true
+then
+    let url = to_url("https://admin:s3cr31@some.host.with.lots.of.subdomains.com:9999/path1/path2/three?q1=something&with_spaces=hello%20graylog&equal=can=containanotherone#anchorstuff");
+    set_fields({
+        protocol: url.protocol,
+        authority: url.authority,
+        user_info: url.userInfo,
+        host: url.host,
+        port: url.port,
+        path: url.path,
+        file: url.file,
+        fragment: url.fragment,
+        query: url.query,
+        q1: url.queryParams.q1,
+        with_spaces: url.queryParams.with_spaces,
+        equal: url.queryParams.equal
+    });
+    trigger_test();
+end


### PR DESCRIPTION
 - hides underlying java.net.URL to prevent people from calling getContent
 - add test for exposed parts of the URL