### PR TITLE
Add syslog-related functions

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogFacilityConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogFacilityConversion.java
@@ -1,0 +1,50 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.syslog;
+
+import com.google.common.primitives.Ints;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class SyslogFacilityConversion extends AbstractFunction<String> {
+    public static final String NAME = "syslog_facility";
+
+    private final ParameterDescriptor<Object, Object> valueParam = object("value").build();
+
+    @Override
+    public String evaluate(FunctionArgs args, EvaluationContext context) {
+        final String s = String.valueOf(valueParam.required(args, context));
+        final Integer facility = firstNonNull(Ints.tryParse(s), -1);
+
+        return SyslogUtils.facilityToString(facility);
+    }
+
+    @Override
+    public FunctionDescriptor<String> descriptor() {
+        return FunctionDescriptor.<String>builder()
+                .name(NAME)
+                .returnType(String.class)
+                .params(valueParam)
+                .build();
+    }
+}

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogLevelConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogLevelConversion.java
@@ -1,0 +1,50 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.syslog;
+
+import com.google.common.primitives.Ints;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class SyslogLevelConversion extends AbstractFunction<String> {
+    public static final String NAME = "syslog_level";
+
+    private final ParameterDescriptor<Object, Object> valueParam = object("value").build();
+
+    @Override
+    public String evaluate(FunctionArgs args, EvaluationContext context) {
+        final String s = String.valueOf(valueParam.required(args, context));
+        final Integer level = firstNonNull(Ints.tryParse(s), -1);
+
+        return SyslogUtils.levelToString(level);
+    }
+
+    @Override
+    public FunctionDescriptor<String> descriptor() {
+        return FunctionDescriptor.<String>builder()
+                .name(NAME)
+                .returnType(String.class)
+                .params(valueParam)
+                .build();
+    }
+}

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogPriority.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogPriority.java
@@ -1,0 +1,30 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.syslog;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class SyslogPriority {
+    public abstract int getLevel();
+
+    public abstract int getFacility();
+
+    public static SyslogPriority create(int level, int facility) {
+        return new AutoValue_SyslogPriority(level, facility);
+    }
+}

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogPriorityAsString.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogPriorityAsString.java
@@ -1,0 +1,30 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.syslog;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class SyslogPriorityAsString {
+    public abstract String getLevel();
+
+    public abstract String getFacility();
+
+    public static SyslogPriorityAsString create(String level, String facility) {
+        return new AutoValue_SyslogPriorityAsString(level, facility);
+    }
+}

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogPriorityConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogPriorityConversion.java
@@ -1,0 +1,50 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.syslog;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class SyslogPriorityConversion extends AbstractFunction<SyslogPriority> {
+    public static final String NAME = "expand_syslog_priority";
+
+    private final ParameterDescriptor<Object, Object> valueParam = object("value").build();
+
+    @Override
+    public SyslogPriority evaluate(FunctionArgs args, EvaluationContext context) {
+        final String s = String.valueOf(valueParam.required(args, context));
+        final int priority = Integer.parseInt(s);
+        final int facility = SyslogUtils.facilityFromPriority(priority);
+        final int level = SyslogUtils.levelFromPriority(priority);
+
+        return SyslogPriority.create(level, facility);
+    }
+
+    @Override
+    public FunctionDescriptor<SyslogPriority> descriptor() {
+        return FunctionDescriptor.<SyslogPriority>builder()
+                .name(NAME)
+                .returnType(SyslogPriority.class)
+                .params(valueParam)
+                .build();
+    }
+}

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogPriorityToStringConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogPriorityToStringConversion.java
@@ -1,0 +1,52 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.syslog;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class SyslogPriorityToStringConversion extends AbstractFunction<SyslogPriorityAsString> {
+    public static final String NAME = "expand_syslog_priority_as_string";
+
+    private final ParameterDescriptor<Object, Object> valueParam = object("value").build();
+
+    @Override
+    public SyslogPriorityAsString evaluate(FunctionArgs args, EvaluationContext context) {
+        final String s = String.valueOf(valueParam.required(args, context));
+        final int priority = Integer.parseInt(s);
+        final int facility = SyslogUtils.facilityFromPriority(priority);
+        final String facilityString = SyslogUtils.facilityToString(facility);
+        final int level = SyslogUtils.levelFromPriority(priority);
+        final String levelString = SyslogUtils.levelToString(level);
+
+        return SyslogPriorityAsString.create(levelString, facilityString);
+    }
+
+    @Override
+    public FunctionDescriptor<SyslogPriorityAsString> descriptor() {
+        return FunctionDescriptor.<SyslogPriorityAsString>builder()
+                .name(NAME)
+                .returnType(SyslogPriorityAsString.class)
+                .params(valueParam)
+                .build();
+    }
+}

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogUtils.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogUtils.java
@@ -1,0 +1,119 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.syslog;
+
+public final class SyslogUtils {
+    /**
+     * Converts integer syslog loglevel to human readable string
+     *
+     * @param level The level to convert
+     * @return The human readable level
+     * @see <a href="https://tools.ietf.org/html/rfc5424#section-6.2.1">RFC 5424, Section 6.2.1</a>
+     */
+    public static String levelToString(int level) {
+        switch (level) {
+            case 0:
+                return "Emergency";
+            case 1:
+                return "Alert";
+            case 2:
+                return "Critical";
+            case 3:
+                return "Error";
+            case 4:
+                return "Warning";
+            case 5:
+                return "Notice";
+            case 6:
+                return "Informational";
+            case 7:
+                return "Debug";
+        }
+
+        return "Unknown";
+    }
+
+    /**
+     * Converts integer syslog facility to human readable string
+     *
+     * @param facility The facility to convert
+     * @return The human readable facility
+     * @see <a href="https://tools.ietf.org/html/rfc5424#section-6.2.1">RFC 5424, Section 6.2.1</a>
+     */
+    public static String facilityToString(int facility) {
+        switch (facility) {
+            case 0:
+                return "kern";
+            case 1:
+                return "user";
+            case 2:
+                return "mail";
+            case 3:
+                return "daemon";
+            case 4:
+                return "auth";
+            case 5:
+                return "syslog";
+            case 6:
+                return "lpr";
+            case 7:
+                return "news";
+            case 8:
+                return "uucp";
+            case 9:
+                return "clock";
+            case 10:
+                return "authpriv";
+            case 11:
+                return "ftp";
+            case 12:
+                return "ntp";
+            case 13:
+                return "log audit";
+            case 14:
+                return "log alert";
+            case 15:
+                return "cron";
+            case 16:
+                return "local0";
+            case 17:
+                return "local1";
+            case 18:
+                return "local2";
+            case 19:
+                return "local3";
+            case 20:
+                return "local4";
+            case 21:
+                return "local5";
+            case 22:
+                return "local6";
+            case 23:
+                return "local7";
+            default:
+                return "Unknown";
+        }
+    }
+
+    public static int levelFromPriority(int priority) {
+        return priority - (facilityFromPriority(priority) << 3);
+    }
+
+    public static int facilityFromPriority(int priority) {
+        return priority >> 3;
+    }
+}

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineRestPermissions.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineRestPermissions.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.pipelineprocessor.rest;
 
 import com.google.common.collect.ImmutableSet;

--- a/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -62,6 +62,10 @@ import org.graylog.plugins.pipelineprocessor.functions.strings.Substring;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Swapcase;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Uncapitalize;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Uppercase;
+import org.graylog.plugins.pipelineprocessor.functions.syslog.SyslogFacilityConversion;
+import org.graylog.plugins.pipelineprocessor.functions.syslog.SyslogLevelConversion;
+import org.graylog.plugins.pipelineprocessor.functions.syslog.SyslogPriorityConversion;
+import org.graylog.plugins.pipelineprocessor.functions.syslog.SyslogPriorityToStringConversion;
 import org.graylog.plugins.pipelineprocessor.functions.urls.UrlConversion;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog.plugins.pipelineprocessor.parser.ParseException;
@@ -163,6 +167,11 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
         functions.put(IsNull.NAME, new IsNull());
         functions.put(IsNotNull.NAME, new IsNotNull());
+
+        functions.put(SyslogPriorityConversion.NAME, new SyslogPriorityConversion());
+        functions.put(SyslogPriorityToStringConversion.NAME, new SyslogPriorityToStringConversion());
+        functions.put(SyslogFacilityConversion.NAME, new SyslogFacilityConversion());
+        functions.put(SyslogLevelConversion.NAME, new SyslogLevelConversion());
 
         functions.put(UrlConversion.NAME, new UrlConversion());
 
@@ -377,5 +386,57 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("with_spaces")).isEqualTo("hello graylog");
         assertThat(message.getField("equal")).isEqualTo("can=containanotherone");
         assertThat(message.getField("authority")).isEqualTo("admin:s3cr31@some.host.with.lots.of.subdomains.com:9999");
+    }
+
+    @Test
+    public void syslog() {
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final Message message = evaluateRule(rule);
+
+        assertThat(actionsTriggered.get()).isTrue();
+        assertThat(message).isNotNull();
+
+        assertThat(message.getField("level0")).isEqualTo("Emergency");
+        assertThat(message.getField("level1")).isEqualTo("Alert");
+        assertThat(message.getField("level2")).isEqualTo("Critical");
+        assertThat(message.getField("level3")).isEqualTo("Error");
+        assertThat(message.getField("level4")).isEqualTo("Warning");
+        assertThat(message.getField("level5")).isEqualTo("Notice");
+        assertThat(message.getField("level6")).isEqualTo("Informational");
+        assertThat(message.getField("level7")).isEqualTo("Debug");
+
+        assertThat(message.getField("facility0")).isEqualTo("kern");
+        assertThat(message.getField("facility1")).isEqualTo("user");
+        assertThat(message.getField("facility2")).isEqualTo("mail");
+        assertThat(message.getField("facility3")).isEqualTo("daemon");
+        assertThat(message.getField("facility4")).isEqualTo("auth");
+        assertThat(message.getField("facility5")).isEqualTo("syslog");
+        assertThat(message.getField("facility6")).isEqualTo("lpr");
+        assertThat(message.getField("facility7")).isEqualTo("news");
+        assertThat(message.getField("facility8")).isEqualTo("uucp");
+        assertThat(message.getField("facility9")).isEqualTo("clock");
+        assertThat(message.getField("facility10")).isEqualTo("authpriv");
+        assertThat(message.getField("facility11")).isEqualTo("ftp");
+        assertThat(message.getField("facility12")).isEqualTo("ntp");
+        assertThat(message.getField("facility13")).isEqualTo("log audit");
+        assertThat(message.getField("facility14")).isEqualTo("log alert");
+        assertThat(message.getField("facility15")).isEqualTo("cron");
+        assertThat(message.getField("facility16")).isEqualTo("local0");
+        assertThat(message.getField("facility17")).isEqualTo("local1");
+        assertThat(message.getField("facility18")).isEqualTo("local2");
+        assertThat(message.getField("facility19")).isEqualTo("local3");
+        assertThat(message.getField("facility20")).isEqualTo("local4");
+        assertThat(message.getField("facility21")).isEqualTo("local5");
+        assertThat(message.getField("facility22")).isEqualTo("local6");
+        assertThat(message.getField("facility23")).isEqualTo("local7");
+
+        assertThat(message.getField("prio1_facility")).isEqualTo(0);
+        assertThat(message.getField("prio1_level")).isEqualTo(0);
+        assertThat(message.getField("prio2_facility")).isEqualTo(20);
+        assertThat(message.getField("prio2_level")).isEqualTo(5);
+        assertThat(message.getField("prio3_facility")).isEqualTo("kern");
+        assertThat(message.getField("prio3_level")).isEqualTo("Emergency");
+        assertThat(message.getField("prio4_facility")).isEqualTo("local4");
+        assertThat(message.getField("prio4_level")).isEqualTo("Notice");
     }
 }

--- a/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PrecedenceTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PrecedenceTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.pipelineprocessor.parser;
 
 import org.graylog.plugins.pipelineprocessor.BaseParserTest;

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/syslog.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/syslog.txt
@@ -1,0 +1,50 @@
+rule "syslog tests"
+when
+    true
+then
+    set_field("level0", syslog_level(0));
+    set_field("level1", syslog_level(1));
+    set_field("level2", syslog_level(2));
+    set_field("level3", syslog_level(3));
+    set_field("level4", syslog_level(4));
+    set_field("level5", syslog_level(5));
+    set_field("level6", syslog_level(6));
+    set_field("level7", syslog_level(7));
+    
+    set_field("facility0", syslog_facility(0));
+    set_field("facility1", syslog_facility(1));
+    set_field("facility2", syslog_facility(2));
+    set_field("facility3", syslog_facility(3));
+    set_field("facility4", syslog_facility(4));
+    set_field("facility5", syslog_facility(5));
+    set_field("facility6", syslog_facility(6));
+    set_field("facility7", syslog_facility(7));
+    set_field("facility8", syslog_facility(8));
+    set_field("facility9", syslog_facility(9));
+    set_field("facility10", syslog_facility(10));
+    set_field("facility11", syslog_facility(11));
+    set_field("facility12", syslog_facility(12));
+    set_field("facility13", syslog_facility(13));
+    set_field("facility14", syslog_facility(14));
+    set_field("facility15", syslog_facility(15));
+    set_field("facility16", syslog_facility(16));
+    set_field("facility17", syslog_facility(17));
+    set_field("facility18", syslog_facility(18));
+    set_field("facility19", syslog_facility(19));
+    set_field("facility20", syslog_facility(20));
+    set_field("facility21", syslog_facility(21));
+    set_field("facility22", syslog_facility(22));
+    set_field("facility23", syslog_facility(23));
+
+    let priority1 = expand_syslog_priority(0);
+    set_fields({prio1_facility: priority1.facility, prio1_level: priority1.level });
+    let priority2 = expand_syslog_priority(165);
+    set_fields({prio2_facility: priority2.facility, prio2_level: priority2.level });
+
+    let priority3 = expand_syslog_priority_as_string(0);
+    set_fields({prio3_facility: priority3.facility, prio3_level: priority3.level });
+    let priority4 = expand_syslog_priority_as_string(165);
+    set_fields({prio4_facility: priority4.facility, prio4_level: priority4.level });
+
+    trigger_test();
+end


### PR DESCRIPTION
This PR adds functions to convert numeric syslog levels or facilities to readable strings (`syslog_level`, `syslog_facility`) and functions to convert syslog priorities to a struct containing numeric/string levels and facilities (`expand_syslog_priority `, `expand_syslog_priority_as_string `).

I'm not 100% happy with the naming of the functions, so better alternatives are welcome.