### PR TITLE
IpAddressConversion caught wrong exception

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddressConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddressConversion.java
@@ -47,7 +47,7 @@ public class IpAddressConversion extends AbstractFunction<IpAddress> {
         try {
             final InetAddress inetAddress = InetAddresses.forString(ipString);
             return new IpAddress(inetAddress);
-        } catch (IllegalFormatException e) {
+        } catch (IllegalArgumentException e) {
             final Optional<String> defaultValue = defaultParam.optional(args, context);
             if (!defaultValue.isPresent()) {
                 return null;

--- a/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -441,4 +441,13 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("prio4_facility")).isEqualTo("local4");
         assertThat(message.getField("prio4_level")).isEqualTo("Notice");
     }
+
+    @Test
+    public void ipMatchingIssue28() {
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final Message in = new Message("some message", "somehost.graylog.org", Tools.nowUTC());
+        evaluateRule(rule, in);
+
+        assertThat(actionsTriggered.get()).isFalse();
+    }
 }

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/ipMatchingIssue28.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/ipMatchingIssue28.txt
@@ -1,0 +1,6 @@
+rule "IP subnet"
+when
+  cidr_match("10.20.30.0/24", to_ip($message.source))
+then
+  trigger_test();
+end


### PR DESCRIPTION
the first try block caught a too specific version of the IllegalArgumentException, allowing the exception to unwind too much.
properly return null or the default value in this case.

fix issue #28