### PR TITLE
Use raw messages on simulator

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulationRequest.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulationRequest.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
 import java.util.Map;
 
 @AutoValue
@@ -31,17 +30,7 @@ public abstract class SimulationRequest {
     public abstract String streamId();
 
     @JsonProperty
-    public abstract String message();
-
-    @JsonProperty
-    public abstract String remoteAddress();
-
-    @JsonProperty
-    public abstract String codec();
-
-    @JsonProperty
-    @Nullable
-    public abstract Map<String, Object> configuration();
+    public abstract Map<String, Object> message();
 
     public static Builder builder() {
         return new AutoValue_SimulationRequest.Builder();
@@ -49,16 +38,10 @@ public abstract class SimulationRequest {
 
     @JsonCreator
     public static SimulationRequest create (@JsonProperty("stream_id") String streamId,
-                                            @JsonProperty("message") String message,
-                                            @JsonProperty("remote_address") String remoteAddress,
-                                            @JsonProperty("codec") String codec,
-                                            @JsonProperty("configuration") Map<String, Object> configuration) {
+                                            @JsonProperty("message") Map<String, Object> message) {
         return builder()
                 .streamId(streamId)
                 .message(message)
-                .remoteAddress(remoteAddress)
-                .codec(codec)
-                .configuration(configuration)
                 .build();
     }
 
@@ -68,12 +51,6 @@ public abstract class SimulationRequest {
 
         public abstract Builder streamId(String streamId);
 
-        public abstract Builder message(String message);
-
-        public abstract Builder remoteAddress(String remoteAddress);
-
-        public abstract Builder codec(String codec);
-
-        public abstract Builder configuration(Map<String, Object> configuration);
+        public abstract Builder message(Map<String, Object> message);
     }
 }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulationRequest.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulationRequest.java
@@ -21,6 +21,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
+import javax.annotation.Nullable;
+import java.util.Map;
+
 @AutoValue
 @JsonAutoDetect
 public abstract class SimulationRequest {
@@ -28,10 +31,17 @@ public abstract class SimulationRequest {
     public abstract String streamId();
 
     @JsonProperty
-    public abstract String index();
+    public abstract String message();
 
     @JsonProperty
-    public abstract String messageId();
+    public abstract String remoteAddress();
+
+    @JsonProperty
+    public abstract String codec();
+
+    @JsonProperty
+    @Nullable
+    public abstract Map<String, Object> configuration();
 
     public static Builder builder() {
         return new AutoValue_SimulationRequest.Builder();
@@ -39,12 +49,16 @@ public abstract class SimulationRequest {
 
     @JsonCreator
     public static SimulationRequest create (@JsonProperty("stream_id") String streamId,
-                                            @JsonProperty("index") String index,
-                                            @JsonProperty("message_id")  String messageId) {
+                                            @JsonProperty("message") String message,
+                                            @JsonProperty("remote_address") String remoteAddress,
+                                            @JsonProperty("codec") String codec,
+                                            @JsonProperty("configuration") Map<String, Object> configuration) {
         return builder()
                 .streamId(streamId)
-                .index(index)
-                .messageId(messageId)
+                .message(message)
+                .remoteAddress(remoteAddress)
+                .codec(codec)
+                .configuration(configuration)
                 .build();
     }
 
@@ -54,8 +68,12 @@ public abstract class SimulationRequest {
 
         public abstract Builder streamId(String streamId);
 
-        public abstract Builder index(String index);
+        public abstract Builder message(String message);
 
-        public abstract Builder messageId(String messageId);
+        public abstract Builder remoteAddress(String remoteAddress);
+
+        public abstract Builder codec(String codec);
+
+        public abstract Builder configuration(Map<String, Object> configuration);
     }
 }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
@@ -24,15 +24,15 @@ import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
 import org.graylog.plugins.pipelineprocessor.simulator.PipelineInterpreterTracer;
 import org.graylog2.database.NotFoundException;
-import org.graylog2.indexer.messages.DocumentNotFoundException;
-import org.graylog2.indexer.messages.Messages;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.messageprocessors.OrderedMessageProcessors;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.messageprocessors.MessageProcessor;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.plugin.streams.Stream;
+import org.graylog2.rest.models.messages.requests.MessageParseRequest;
 import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
+import org.graylog2.rest.resources.messages.MessageResource;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.streams.StreamService;
@@ -54,13 +54,13 @@ import java.util.List;
 @RequiresAuthentication
 public class SimulatorResource extends RestResource implements PluginRestResource {
     private final OrderedMessageProcessors orderedMessageProcessors;
-    private final Messages messages;
+    private final MessageResource messageResource;
     private final StreamService streamService;
 
     @Inject
-    public SimulatorResource(OrderedMessageProcessors orderedMessageProcessors, Messages messages, StreamService streamService) {
+    public SimulatorResource(OrderedMessageProcessors orderedMessageProcessors, MessageResource messageResource, StreamService streamService) {
         this.orderedMessageProcessors = orderedMessageProcessors;
-        this.messages = messages;
+        this.messageResource = messageResource;
         this.streamService = streamService;
     }
 
@@ -68,31 +68,31 @@ public class SimulatorResource extends RestResource implements PluginRestResourc
     @POST
     @RequiresPermissions(PipelineRestPermissions.PIPELINE_RULE_READ)
     public SimulationResponse simulate(@ApiParam(name = "simulation", required = true) @NotNull SimulationRequest request) throws NotFoundException {
-        checkPermission(RestPermissions.MESSAGES_READ, request.messageId());
         checkPermission(RestPermissions.STREAMS_READ, request.streamId());
-        try {
-            final ResultMessage resultMessage = messages.get(request.messageId(), request.index());
-            final Message message = resultMessage.getMessage();
-            if (!request.streamId().equals("default")) {
-                final Stream stream = streamService.load(request.streamId());
-                message.addStream(stream);
-            }
+        final ResultMessage resultMessage = messageResource.parse(MessageParseRequest.create(
+                request.message(),
+                request.codec(),
+                request.remoteAddress(),
+                request.configuration()));
 
-            final List<ResultMessageSummary> simulationResults = new ArrayList<>();
-            final PipelineInterpreterTracer pipelineInterpreterTracer = new PipelineInterpreterTracer();
+        final Message message = resultMessage.getMessage();
+        if (!request.streamId().equals("default")) {
+            final Stream stream = streamService.load(request.streamId());
+            message.addStream(stream);
+        }
 
-            for (MessageProcessor messageProcessor : orderedMessageProcessors) {
-                if (messageProcessor instanceof PipelineInterpreter) {
-                    org.graylog2.plugin.Messages processedMessages = ((PipelineInterpreter)messageProcessor).process(message, pipelineInterpreterTracer.getSimulatorInterpreterListener());
-                    for (Message processedMessage : processedMessages) {
-                        simulationResults.add(ResultMessageSummary.create(null, processedMessage.getFields(), ""));
-                    }
+        final List<ResultMessageSummary> simulationResults = new ArrayList<>();
+        final PipelineInterpreterTracer pipelineInterpreterTracer = new PipelineInterpreterTracer();
+
+        for (MessageProcessor messageProcessor : orderedMessageProcessors) {
+            if (messageProcessor instanceof PipelineInterpreter) {
+                org.graylog2.plugin.Messages processedMessages = ((PipelineInterpreter) messageProcessor).process(message, pipelineInterpreterTracer.getSimulatorInterpreterListener());
+                for (Message processedMessage : processedMessages) {
+                    simulationResults.add(ResultMessageSummary.create(null, processedMessage.getFields(), ""));
                 }
             }
-
-            return SimulationResponse.create(simulationResults, pipelineInterpreterTracer.getExecutionTrace(), pipelineInterpreterTracer.took());
-        } catch (DocumentNotFoundException e) {
-            throw new NotFoundException(e);
         }
+
+        return SimulationResponse.create(simulationResults, pipelineInterpreterTracer.getExecutionTrace(), pipelineInterpreterTracer.took());
     }
 }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
@@ -24,13 +24,11 @@ import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
 import org.graylog.plugins.pipelineprocessor.simulator.PipelineInterpreterTracer;
 import org.graylog2.database.NotFoundException;
-import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.messageprocessors.OrderedMessageProcessors;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.messageprocessors.MessageProcessor;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.plugin.streams.Stream;
-import org.graylog2.rest.models.messages.requests.MessageParseRequest;
 import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
 import org.graylog2.rest.resources.messages.MessageResource;
 import org.graylog2.shared.rest.resources.RestResource;
@@ -69,13 +67,8 @@ public class SimulatorResource extends RestResource implements PluginRestResourc
     @RequiresPermissions(PipelineRestPermissions.PIPELINE_RULE_READ)
     public SimulationResponse simulate(@ApiParam(name = "simulation", required = true) @NotNull SimulationRequest request) throws NotFoundException {
         checkPermission(RestPermissions.STREAMS_READ, request.streamId());
-        final ResultMessage resultMessage = messageResource.parse(MessageParseRequest.create(
-                request.message(),
-                request.codec(),
-                request.remoteAddress(),
-                request.configuration()));
 
-        final Message message = resultMessage.getMessage();
+        final Message message = new Message(request.message());
         if (!request.streamId().equals("default")) {
             final Stream stream = streamService.load(request.streamId());
             message.addStream(stream);

--- a/src/web/simulator/ProcessorSimulator.jsx
+++ b/src/web/simulator/ProcessorSimulator.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Col, Row } from 'react-bootstrap';
 
-import LoaderTabs from 'components/messageloaders/LoaderTabs';
+import RawMessageLoader from 'components/messageloaders/RawMessageLoader';
 import SimulationResults from './SimulationResults';
 
 import SimulatorActions from './SimulatorActions';
+// eslint-disable-next-line no-unused-vars
 import SimulatorStore from './SimulatorStore';
 
 const ProcessorSimulator = React.createClass({
@@ -21,17 +22,19 @@ const ProcessorSimulator = React.createClass({
     };
   },
 
-  _onMessageLoad(message) {
+  _onMessageLoad(message, params) {
     this.setState({ message: message, simulation: undefined, loading: true, error: undefined });
 
-    SimulatorActions.simulate.triggerPromise(this.props.stream, message.index, message.id).then(
-      response => {
-        this.setState({ simulation: response, loading: false });
-      },
-      error => {
-        this.setState({ loading: false, error: error });
-      }
-    );
+    SimulatorActions.simulate
+      .triggerPromise(this.props.stream, params.message, params.remoteAddress, params.codec, params.codecConfiguration)
+      .then(
+        response => {
+          this.setState({ simulation: response, loading: false });
+        },
+        error => {
+          this.setState({ loading: false, error: error });
+        }
+      );
   },
 
   render() {
@@ -42,7 +45,7 @@ const ProcessorSimulator = React.createClass({
             <h1>Load a message</h1>
             <p>Load a message to be used in the simulation. <strong>No changes will be done in your stored
               messages.</strong></p>
-            <LoaderTabs onMessageLoaded={this._onMessageLoad} disableMessagePreview />
+            <RawMessageLoader onMessageLoaded={this._onMessageLoad} />
           </Col>
         </Row>
         <SimulationResults stream={this.props.stream}

--- a/src/web/simulator/ProcessorSimulator.jsx
+++ b/src/web/simulator/ProcessorSimulator.jsx
@@ -22,11 +22,11 @@ const ProcessorSimulator = React.createClass({
     };
   },
 
-  _onMessageLoad(message, params) {
+  _onMessageLoad(message) {
     this.setState({ message: message, simulation: undefined, loading: true, error: undefined });
 
     SimulatorActions.simulate
-      .triggerPromise(this.props.stream, params.message, params.remoteAddress, params.codec, params.codecConfiguration)
+      .triggerPromise(this.props.stream, message.fields)
       .then(
         response => {
           this.setState({ simulation: response, loading: false });
@@ -43,8 +43,10 @@ const ProcessorSimulator = React.createClass({
         <Row>
           <Col md={12}>
             <h1>Load a message</h1>
-            <p>Load a message to be used in the simulation. <strong>No changes will be done in your stored
-              messages.</strong></p>
+            <p>
+              Load a message to be used in the simulation.{' '}
+              <strong>No changes will be done in your stored messages.</strong>
+            </p>
             <RawMessageLoader onMessageLoaded={this._onMessageLoad} />
           </Col>
         </Row>

--- a/src/web/simulator/SimulatorStore.js
+++ b/src/web/simulator/SimulatorStore.js
@@ -25,7 +25,7 @@ const SimulatorStore = Reflux.createStore({
     let promise = fetch('POST', url, simulation);
     promise = promise.then(response => {
       const formattedResponse = ObjectUtils.clone(response);
-      formattedResponse.messages = response.messages.map(message => MessageFormatter.formatMessageSummary(message));
+      formattedResponse.messages = response.messages.map(msg => MessageFormatter.formatMessageSummary(msg));
 
       return formattedResponse;
     });

--- a/src/web/simulator/SimulatorStore.js
+++ b/src/web/simulator/SimulatorStore.js
@@ -12,14 +12,11 @@ const urlPrefix = '/plugins/org.graylog.plugins.pipelineprocessor';
 const SimulatorStore = Reflux.createStore({
   listenables: [SimulatorActions],
 
-  simulate(stream, message, remoteAddress, codec, codecConfiguration) {
+  simulate(stream, messageFields) {
     const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/simulate`);
     const simulation = {
       stream_id: stream.id,
-      message: message,
-      remote_address: remoteAddress,
-      codec: codec,
-      configuration: codecConfiguration,
+      message: messageFields,
     };
 
     let promise = fetch('POST', url, simulation);

--- a/src/web/simulator/SimulatorStore.js
+++ b/src/web/simulator/SimulatorStore.js
@@ -12,12 +12,14 @@ const urlPrefix = '/plugins/org.graylog.plugins.pipelineprocessor';
 const SimulatorStore = Reflux.createStore({
   listenables: [SimulatorActions],
 
-  simulate(stream, index, messageId) {
+  simulate(stream, message, remoteAddress, codec, codecConfiguration) {
     const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/simulate`);
     const simulation = {
       stream_id: stream.id,
-      index: index,
-      message_id: messageId,
+      message: message,
+      remote_address: remoteAddress,
+      codec: codec,
+      configuration: codecConfiguration,
     };
 
     let promise = fetch('POST', url, simulation);

--- a/src/web/simulator/SimulatorStore.js
+++ b/src/web/simulator/SimulatorStore.js
@@ -23,7 +23,7 @@ const SimulatorStore = Reflux.createStore({
     let promise = fetch('POST', url, simulation);
     promise = promise.then(response => {
       const formattedResponse = ObjectUtils.clone(response);
-      formattedResponse.messages = response.messages.map(MessageFormatter.formatMessageSummary);
+      formattedResponse.messages = response.messages.map(message => MessageFormatter.formatMessageSummary(message));
 
       return formattedResponse;
     });


### PR DESCRIPTION
As simulating the result of already processed messages can become really tricky, this PR replaces the message loader used in the pipeline simulator, using the new raw message loader available in https://github.com/Graylog2/graylog2-server/pull/2438. Therefore, we need to wait merging this until the referring PR is merged into master.