### PR TITLE
Adapt to changed decorators interface

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
@@ -1,27 +1,96 @@
 package org.graylog.plugins.pipelineprocessor;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
+import com.google.inject.assistedinject.Assisted;
+import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
+import org.graylog.plugins.pipelineprocessor.db.PipelineService;
 import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
+import org.graylog2.decorators.Decorator;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.Message;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.ConfigurationField;
+import org.graylog2.plugin.configuration.fields.DropdownField;
 import org.graylog2.plugin.decorators.MessageDecorator;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class PipelineProcessorMessageDecorator implements MessageDecorator {
+    private static final String CONFIG_FIELD_PIPELINE = "pipeline";
+
     private final PipelineInterpreter pipelineInterpreter;
+    private final ImmutableSet<String> pipelines;
+
+    public interface Factory extends MessageDecorator.Factory {
+        @Override
+        PipelineProcessorMessageDecorator create(Decorator decorator);
+
+        @Override
+        Config getConfig();
+
+        @Override
+        Descriptor getDescriptor();
+    }
+
+    public static class Config implements MessageDecorator.Config {
+        private final PipelineService pipelineService;
+
+        @Inject
+        public Config(PipelineService pipelineService) {
+            this.pipelineService = pipelineService;
+        }
+
+        @Override
+        public ConfigurationRequest getRequestedConfiguration() {
+            final Map<String, String> pipelineOptions = this.pipelineService.loadAll().stream()
+                    .sorted((o1, o2) -> o1.title().compareTo(o2.title()))
+                    .collect(Collectors.toMap(PipelineDao::id, PipelineDao::title));
+            return new ConfigurationRequest() {{
+                addField(new DropdownField(CONFIG_FIELD_PIPELINE,
+                        "Pipeline",
+                        "",
+                        pipelineOptions,
+                        "Which pipeline to use for message decoration",
+                        ConfigurationField.Optional.NOT_OPTIONAL));
+            }};
+        };
+    }
+
+    public static class Descriptor extends MessageDecorator.Descriptor {
+        public Descriptor() {
+            super("Pipeline Processor Decorator", false, "http://docs.graylog.org/en/2.0/pages/pipelines.html", "Pipeline Processor Decorator");
+        }
+    }
 
     @Inject
-    public PipelineProcessorMessageDecorator(PipelineInterpreter pipelineInterpreter) {
+    public PipelineProcessorMessageDecorator(PipelineInterpreter pipelineInterpreter,
+                                             @Assisted Decorator decorator) {
         this.pipelineInterpreter = pipelineInterpreter;
+        final String pipelineId = (String)decorator.config().get(CONFIG_FIELD_PIPELINE);
+        if (Strings.isNullOrEmpty(pipelineId)) {
+            this.pipelines = ImmutableSet.of();
+        } else {
+            this.pipelines = ImmutableSet.of(pipelineId);
+        }
     }
 
     @Override
-    public ResultMessage apply(ResultMessage resultMessage) {
-        final Message message = resultMessage.getMessage();
-        final List<Message> messages = pipelineInterpreter.processForPipelines(message, message.getId(), ImmutableSet.of("575ea96d726bd1e03ebb63e7"));
-        resultMessage.setMessage(message);
-        return resultMessage;
+    public List<ResultMessage> apply(List<ResultMessage> resultMessages) {
+        if (pipelines.isEmpty()) {
+            return resultMessages;
+        }
+        return resultMessages.stream()
+                .map((resultMessage) -> {
+                    final Message message = resultMessage.getMessage();
+                    // discarding return type, as we cannot add more messages to the result message set yet.
+                    pipelineInterpreter.processForPipelines(message, message.getId(), pipelines);
+                    resultMessage.setMessage(message);
+                    return resultMessage;
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
@@ -1,0 +1,27 @@
+package org.graylog.plugins.pipelineprocessor;
+
+import com.google.common.collect.ImmutableSet;
+import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
+import org.graylog2.indexer.results.ResultMessage;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.decorators.MessageDecorator;
+
+import javax.inject.Inject;
+import java.util.List;
+
+public class PipelineProcessorMessageDecorator implements MessageDecorator {
+    private final PipelineInterpreter pipelineInterpreter;
+
+    @Inject
+    public PipelineProcessorMessageDecorator(PipelineInterpreter pipelineInterpreter) {
+        this.pipelineInterpreter = pipelineInterpreter;
+    }
+
+    @Override
+    public ResultMessage apply(ResultMessage resultMessage) {
+        final Message message = resultMessage.getMessage();
+        final List<Message> messages = pipelineInterpreter.processForPipelines(message, message.getId(), ImmutableSet.of("575ea96d726bd1e03ebb63e7"));
+        resultMessage.setMessage(message);
+        return resultMessage;
+    }
+}

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
@@ -8,6 +8,7 @@ import com.google.inject.assistedinject.Assisted;
 import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
 import org.graylog.plugins.pipelineprocessor.db.PipelineService;
 import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
+import org.graylog.plugins.pipelineprocessor.processors.listeners.NoopInterpreterListener;
 import org.graylog2.decorators.Decorator;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.Message;
@@ -91,7 +92,10 @@ public class PipelineProcessorMessageDecorator implements MessageDecorator {
         resultMessages.stream()
                 .forEach((inMessage) -> {
                     final Message message = inMessage.getMessage();
-                    final List<Message> additionalCreatedMessages = pipelineInterpreter.processForPipelines(message, message.getId(), pipelines);
+                    final List<Message> additionalCreatedMessages = pipelineInterpreter.processForPipelines(message,
+                            message.getId(),
+                            pipelines,
+                            new NoopInterpreterListener());
                     final ResultMessage outMessage = ResultMessage.fromMessage(message, inMessage.getIndex(), inMessage.getHighlightRanges());
 
                     results.add(outMessage);

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
@@ -89,21 +89,20 @@ public class PipelineProcessorMessageDecorator implements MessageDecorator {
         if (pipelines.isEmpty()) {
             return resultMessages;
         }
-        resultMessages.stream()
-                .forEach((inMessage) -> {
-                    final Message message = inMessage.getMessage();
-                    final List<Message> additionalCreatedMessages = pipelineInterpreter.processForPipelines(message,
-                            message.getId(),
-                            pipelines,
-                            new NoopInterpreterListener());
-                    final ResultMessage outMessage = ResultMessage.fromMessage(message, inMessage.getIndex(), inMessage.getHighlightRanges());
+        resultMessages.forEach((inMessage) -> {
+            final Message message = inMessage.getMessage();
+            final List<Message> additionalCreatedMessages = pipelineInterpreter.processForPipelines(message,
+                    message.getId(),
+                    pipelines,
+                    new NoopInterpreterListener());
+            final ResultMessage outMessage = ResultMessage.createFromMessage(message, inMessage.getIndex(), inMessage.getHighlightRanges());
 
-                    results.add(outMessage);
-                    additionalCreatedMessages.stream().forEach((additionalMessage) -> {
-                        // TODO: pass proper highlight ranges. Need to rebuild them for new messages.
-                        results.add(ResultMessage.fromMessage(additionalMessage, "[created from decorator]", ImmutableMultimap.of()));
-                    });
-                });
+            results.add(outMessage);
+            additionalCreatedMessages.forEach((additionalMessage) -> {
+                // TODO: pass proper highlight ranges. Need to rebuild them for new messages.
+                results.add(ResultMessage.createFromMessage(additionalMessage, "[created from decorator]", ImmutableMultimap.of()));
+            });
+        });
 
         return results;
     }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
@@ -3,34 +3,33 @@ package org.graylog.plugins.pipelineprocessor;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
 import com.google.inject.assistedinject.Assisted;
 import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
 import org.graylog.plugins.pipelineprocessor.db.PipelineService;
 import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
 import org.graylog.plugins.pipelineprocessor.processors.listeners.NoopInterpreterListener;
 import org.graylog2.decorators.Decorator;
-import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.configuration.fields.ConfigurationField;
 import org.graylog2.plugin.configuration.fields.DropdownField;
-import org.graylog2.plugin.decorators.MessageDecorator;
+import org.graylog2.plugin.decorators.SearchResponseDecorator;
+import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
+import org.graylog2.rest.resources.search.responses.SearchResponse;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class PipelineProcessorMessageDecorator implements MessageDecorator {
+public class PipelineProcessorMessageDecorator implements SearchResponseDecorator {
     private static final String CONFIG_FIELD_PIPELINE = "pipeline";
 
     private final PipelineInterpreter pipelineInterpreter;
     private final ImmutableSet<String> pipelines;
 
-    public interface Factory extends MessageDecorator.Factory {
+    public interface Factory extends SearchResponseDecorator.Factory {
         @Override
         PipelineProcessorMessageDecorator create(Decorator decorator);
 
@@ -41,7 +40,7 @@ public class PipelineProcessorMessageDecorator implements MessageDecorator {
         Descriptor getDescriptor();
     }
 
-    public static class Config implements MessageDecorator.Config {
+    public static class Config implements SearchResponseDecorator.Config {
         private final PipelineService pipelineService;
 
         @Inject
@@ -65,7 +64,7 @@ public class PipelineProcessorMessageDecorator implements MessageDecorator {
         };
     }
 
-    public static class Descriptor extends MessageDecorator.Descriptor {
+    public static class Descriptor extends SearchResponseDecorator.Descriptor {
         public Descriptor() {
             super("Pipeline Processor Decorator", false, "http://docs.graylog.org/en/2.0/pages/pipelines.html", "Pipeline Processor Decorator");
         }
@@ -84,26 +83,25 @@ public class PipelineProcessorMessageDecorator implements MessageDecorator {
     }
 
     @Override
-    public List<ResultMessage> apply(List<ResultMessage> resultMessages) {
-        final List<ResultMessage> results = new ArrayList<>();
+    public SearchResponse apply(SearchResponse searchResponse) {
+        final List<ResultMessageSummary> results = new ArrayList<>();
         if (pipelines.isEmpty()) {
-            return resultMessages;
+            return searchResponse;
         }
-        resultMessages.forEach((inMessage) -> {
-            final Message message = inMessage.getMessage();
+        searchResponse.messages().forEach((inMessage) -> {
+            final Message message = new Message(inMessage.message());
             final List<Message> additionalCreatedMessages = pipelineInterpreter.processForPipelines(message,
                     message.getId(),
                     pipelines,
                     new NoopInterpreterListener());
-            final ResultMessage outMessage = ResultMessage.createFromMessage(message, inMessage.getIndex(), inMessage.getHighlightRanges());
 
-            results.add(outMessage);
+            results.add(ResultMessageSummary.create(inMessage.highlightRanges(), message.getFields(), inMessage.index()));
             additionalCreatedMessages.forEach((additionalMessage) -> {
                 // TODO: pass proper highlight ranges. Need to rebuild them for new messages.
-                results.add(ResultMessage.createFromMessage(additionalMessage, "[created from decorator]", ImmutableMultimap.of()));
+                results.add(ResultMessageSummary.create(ImmutableMultimap.of(), additionalMessage.getFields(), "[created from decorator]"));
             });
         });
 
-        return results;
+        return searchResponse.toBuilder().messages(results).build();
     }
 }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
@@ -46,5 +46,7 @@ public class PipelineProcessorModule extends PluginModule {
         addPermissions(PipelineRestPermissions.class);
 
         install(new ProcessorFunctionsModule());
+
+        installMessageDecorator(messageDecoratorBinder(), PipelineProcessorMessageDecorator.class);
     }
 }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
@@ -47,6 +47,8 @@ public class PipelineProcessorModule extends PluginModule {
 
         install(new ProcessorFunctionsModule());
 
-        installMessageDecorator(messageDecoratorBinder(), PipelineProcessorMessageDecorator.class, PipelineProcessorMessageDecorator.Factory.class);
+        installSearchResponseDecorator(searchResponseDecoratorBinder(),
+                PipelineProcessorMessageDecorator.class,
+                PipelineProcessorMessageDecorator.Factory.class);
     }
 }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
@@ -47,6 +47,6 @@ public class PipelineProcessorModule extends PluginModule {
 
         install(new ProcessorFunctionsModule());
 
-        installMessageDecorator(messageDecoratorBinder(), PipelineProcessorMessageDecorator.class);
+        installMessageDecorator(messageDecoratorBinder(), PipelineProcessorMessageDecorator.class, PipelineProcessorMessageDecorator.Factory.class);
     }
 }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -235,7 +235,7 @@ public class PipelineInterpreter implements MessageProcessor {
                     log.debug("[{}] running pipelines {} for streams {}", msgId, pipelinesToRun, streamsIds);
                 }
 
-                toProcess.addAll(processForPipelines(message, msgId, pipelinesToRun.stream().map(Pipeline::id).collect(Collectors.toSet())));
+                toProcess.addAll(processForPipelines(message, msgId, pipelinesToRun.stream().map(Pipeline::id).collect(Collectors.toSet()), interpreterListener));
 
                 boolean addedStreams = false;
                 // 5. add each message-stream combination to the blacklist set

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -235,108 +235,8 @@ public class PipelineInterpreter implements MessageProcessor {
                     log.debug("[{}] running pipelines {} for streams {}", msgId, pipelinesToRun, streamsIds);
                 }
 
-                // record execution of pipeline in metrics
-                pipelinesToRun.stream().forEach(pipeline -> metricRegistry.counter(name(Pipeline.class, pipeline.id(), "executed")).inc());
+                toProcess.addAll(processForPipelines(message, msgId, pipelinesToRun.stream().map(Pipeline::id).collect(Collectors.toSet())));
 
-                final StageIterator stages = new StageIterator(pipelinesToRun);
-                final Set<Pipeline> pipelinesToSkip = Sets.newHashSet();
-
-                // iterate through all stages for all matching pipelines, per "stage slice" instead of per pipeline.
-                // pipeline execution ordering is not guaranteed
-                while (stages.hasNext()) {
-                    final Set<Tuple2<Stage, Pipeline>> stageSet = stages.next();
-                    for (Tuple2<Stage, Pipeline> pair : stageSet) {
-                        final Stage stage = pair.v1();
-                        final Pipeline pipeline = pair.v2();
-                        if (pipelinesToSkip.contains(pipeline)) {
-                            log.debug("[{}] previous stage result prevents further processing of pipeline `{}`",
-                                     msgId,
-                                     pipeline.name());
-                            continue;
-                        }
-                        metricRegistry.counter(name(Pipeline.class, pipeline.id(), "stage", String.valueOf(stage.stage()), "executed")).inc();
-                        interpreterListener.enterStage(stage);
-                        log.debug("[{}] evaluating rule conditions in stage {}: match {}",
-                                 msgId,
-                                 stage.stage(),
-                                 stage.matchAll() ? "all" : "either");
-
-                        // TODO the message should be decorated to allow layering changes and isolate stages
-                        final EvaluationContext context = new EvaluationContext(message);
-
-                        // 3. iterate over all the stages in these pipelines and execute them in order
-                        final ArrayList<Rule> rulesToRun = Lists.newArrayListWithCapacity(stage.getRules().size());
-                        boolean anyRulesMatched = false;
-                        for (Rule rule : stage.getRules()) {
-                            interpreterListener.evaluateRule(rule, pipeline);
-                            if (rule.when().evaluateBool(context)) {
-                                anyRulesMatched = true;
-                                countRuleExecution(rule, pipeline, stage, "matched");
-
-                                if (context.hasEvaluationErrors()) {
-                                    final EvaluationContext.EvalError lastError = Iterables.getLast(context.evaluationErrors());
-                                    appendProcessingError(rule, message, lastError.toString());
-                                    interpreterListener.failEvaluateRule(rule, pipeline);
-                                    log.debug("Encountered evaluation error during condition, skipping rule actions: {}",
-                                              lastError);
-                                    continue;
-                                }
-                                interpreterListener.satisfyRule(rule, pipeline);
-                                log.debug("[{}] rule `{}` matches, scheduling to run", msgId, rule.name());
-                                rulesToRun.add(rule);
-                            } else {
-                                countRuleExecution(rule, pipeline, stage, "not-matched");
-                                interpreterListener.dissatisfyRule(rule, pipeline);
-                                log.debug("[{}] rule `{}` does not match", msgId, rule.name());
-                            }
-                        }
-                        RULES:
-                        for (Rule rule : rulesToRun) {
-                            countRuleExecution(rule, pipeline, stage, "executed");
-                            interpreterListener.executeRule(rule, pipeline);
-                            log.debug("[{}] rule `{}` matched running actions", msgId, rule.name());
-                            for (Statement statement : rule.then()) {
-                                statement.evaluate(context);
-                                if (context.hasEvaluationErrors()) {
-                                    // if the last statement resulted in an error, do not continue to execute this rules
-                                    final EvaluationContext.EvalError lastError = Iterables.getLast(context.evaluationErrors());
-                                    appendProcessingError(rule, message, lastError.toString());
-                                    interpreterListener.failExecuteRule(rule, pipeline);
-                                    log.debug("Encountered evaluation error, skipping rest of the rule: {}",
-                                              lastError);
-                                    countRuleExecution(rule, pipeline, stage, "failed");
-                                    break RULES;
-                                }
-                            }
-                        }
-                        // stage needed to match all rule conditions to enable the next stage,
-                        // record that it is ok to proceed with this pipeline
-                        // OR
-                        // any rule could match, but at least one had to,
-                        // record that it is ok to proceed with the pipeline
-                        if ((stage.matchAll() && (rulesToRun.size() == stage.getRules().size()))
-                                || (rulesToRun.size() > 0 && anyRulesMatched)) {
-                            interpreterListener.continuePipelineExecution(pipeline, stage);
-                            log.debug("[{}] stage {} for pipeline `{}` required match: {}, ok to proceed with next stage",
-                                     msgId, stage.stage(), pipeline.name(), stage.matchAll() ? "all" : "either");
-                        } else {
-                            // no longer execute stages from this pipeline, the guard prevents it
-                            interpreterListener.stopPipelineExecution(pipeline, stage);
-                            log.debug("[{}] stage {} for pipeline `{}` required match: {}, NOT ok to proceed with next stage",
-                                      msgId, stage.stage(), pipeline.name(), stage.matchAll() ? "all" : "either");
-                            pipelinesToSkip.add(pipeline);
-                        }
-
-                        // 4. after each complete stage run, merge the processing changes, stages are isolated from each other
-                        // TODO message changes become visible immediately for now
-
-                        // 4a. also add all new messages from the context to the toProcess work list
-                        Iterables.addAll(toProcess, context.createdMessages());
-                        context.clearCreatedMessages();
-                        interpreterListener.exitStage(stage);
-                    }
-
-                }
                 boolean addedStreams = false;
                 // 5. add each message-stream combination to the blacklist set
                 for (Stream stream : message.getStreams()) {
@@ -365,10 +265,118 @@ public class PipelineInterpreter implements MessageProcessor {
                 }
             }
         }
+        // 7. return the processed messages
+        return new MessageCollection(fullyProcessed);
+    }
+
+    public List<Message> processForPipelines(Message message, String msgId, Set<String> pipelines, InterpreterListener interpreterListener) {
+        final ImmutableSet<Pipeline> pipelinesToRun = ImmutableSet.copyOf(pipelines.stream().map(pipelineId -> this.currentPipelines.get().get(pipelineId)).collect(Collectors.toSet()));
+        final List<Message> result = new ArrayList<>();
+        // record execution of pipeline in metrics
+        pipelinesToRun.stream().forEach(pipeline -> metricRegistry.counter(name(Pipeline.class, pipeline.id(), "executed")).inc());
+
+        final StageIterator stages = new StageIterator(pipelinesToRun);
+        final Set<Pipeline> pipelinesToSkip = Sets.newHashSet();
+
+        // iterate through all stages for all matching pipelines, per "stage slice" instead of per pipeline.
+        // pipeline execution ordering is not guaranteed
+        while (stages.hasNext()) {
+            final Set<Tuple2<Stage, Pipeline>> stageSet = stages.next();
+            for (Tuple2<Stage, Pipeline> pair : stageSet) {
+                final Stage stage = pair.v1();
+                final Pipeline pipeline = pair.v2();
+                if (pipelinesToSkip.contains(pipeline)) {
+                    log.debug("[{}] previous stage result prevents further processing of pipeline `{}`",
+                             msgId,
+                             pipeline.name());
+                    continue;
+                }
+                metricRegistry.counter(name(Pipeline.class, pipeline.id(), "stage", String.valueOf(stage.stage()), "executed")).inc();
+                interpreterListener.enterStage(stage);
+                log.debug("[{}] evaluating rule conditions in stage {}: match {}",
+                         msgId,
+                         stage.stage(),
+                         stage.matchAll() ? "all" : "either");
+
+                // TODO the message should be decorated to allow layering changes and isolate stages
+                final EvaluationContext context = new EvaluationContext(message);
+
+                // 3. iterate over all the stages in these pipelines and execute them in order
+                final ArrayList<Rule> rulesToRun = Lists.newArrayListWithCapacity(stage.getRules().size());
+                boolean anyRulesMatched = false;
+                for (Rule rule : stage.getRules()) {
+                    interpreterListener.evaluateRule(rule, pipeline);
+                    if (rule.when().evaluateBool(context)) {
+                        anyRulesMatched = true;
+                        countRuleExecution(rule, pipeline, stage, "matched");
+
+                        if (context.hasEvaluationErrors()) {
+                            final EvaluationContext.EvalError lastError = Iterables.getLast(context.evaluationErrors());
+                            appendProcessingError(rule, message, lastError.toString());
+                            interpreterListener.failEvaluateRule(rule, pipeline);
+                            log.debug("Encountered evaluation error during condition, skipping rule actions: {}",
+                                      lastError);
+                            continue;
+                        }
+                        interpreterListener.satisfyRule(rule, pipeline);
+                        log.debug("[{}] rule `{}` matches, scheduling to run", msgId, rule.name());
+                        rulesToRun.add(rule);
+                    } else {
+                        countRuleExecution(rule, pipeline, stage, "not-matched");
+                        interpreterListener.dissatisfyRule(rule, pipeline);
+                        log.debug("[{}] rule `{}` does not match", msgId, rule.name());
+                    }
+                }
+                RULES:
+                for (Rule rule : rulesToRun) {
+                    countRuleExecution(rule, pipeline, stage, "executed");
+                    interpreterListener.executeRule(rule, pipeline);
+                    log.debug("[{}] rule `{}` matched running actions", msgId, rule.name());
+                    for (Statement statement : rule.then()) {
+                        statement.evaluate(context);
+                        if (context.hasEvaluationErrors()) {
+                            // if the last statement resulted in an error, do not continue to execute this rules
+                            final EvaluationContext.EvalError lastError = Iterables.getLast(context.evaluationErrors());
+                            appendProcessingError(rule, message, lastError.toString());
+                            interpreterListener.failExecuteRule(rule, pipeline);
+                            log.debug("Encountered evaluation error, skipping rest of the rule: {}",
+                                      lastError);
+                            countRuleExecution(rule, pipeline, stage, "failed");
+                            break RULES;
+                        }
+                    }
+                }
+                // stage needed to match all rule conditions to enable the next stage,
+                // record that it is ok to proceed with this pipeline
+                // OR
+                // any rule could match, but at least one had to,
+                // record that it is ok to proceed with the pipeline
+                if ((stage.matchAll() && (rulesToRun.size() == stage.getRules().size()))
+                        || (rulesToRun.size() > 0 && anyRulesMatched)) {
+                    interpreterListener.continuePipelineExecution(pipeline, stage);
+                    log.debug("[{}] stage {} for pipeline `{}` required match: {}, ok to proceed with next stage",
+                             msgId, stage.stage(), pipeline.name(), stage.matchAll() ? "all" : "either");
+                } else {
+                    // no longer execute stages from this pipeline, the guard prevents it
+                    interpreterListener.stopPipelineExecution(pipeline, stage);
+                    log.debug("[{}] stage {} for pipeline `{}` required match: {}, NOT ok to proceed with next stage",
+                              msgId, stage.stage(), pipeline.name(), stage.matchAll() ? "all" : "either");
+                    pipelinesToSkip.add(pipeline);
+                }
+
+                // 4. after each complete stage run, merge the processing changes, stages are isolated from each other
+                // TODO message changes become visible immediately for now
+
+                // 4a. also add all new messages from the context to the toProcess work list
+                Iterables.addAll(result, context.createdMessages());
+                context.clearCreatedMessages();
+                interpreterListener.exitStage(stage);
+            }
+        }
 
         interpreterListener.finishProcessing();
         // 7. return the processed messages
-        return new MessageCollection(fullyProcessed);
+        return result;
     }
 
     private void countRuleExecution(Rule rule, Pipeline pipeline, Stage stage, String type) {


### PR DESCRIPTION
We are now operating on a `SearchResponse` object instead of `List<ResultMessage>`. This allows us to implement functionality which updates the fields list and probably add additional metadata to the search response.

Requires merging #41.