### PR TITLE
Unescape string literals before using them

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
@@ -31,6 +31,7 @@ import org.antlr.v4.runtime.RuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTreeProperty;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.mina.util.IdentityHashSet;
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
@@ -192,6 +193,10 @@ public class PipelineRuleParser {
             return string.substring(1, string.length() - 1);
         }
         return string;
+    }
+
+    public static String unescape(String string) {
+        return StringEscapeUtils.unescapeJava(string);
     }
 
     private static class SyntaxErrorListener extends BaseErrorListener {
@@ -474,7 +479,7 @@ public class PipelineRuleParser {
 
         @Override
         public void exitString(RuleLangParser.StringContext ctx) {
-            final String text = unquote(ctx.getText(), '\"');
+            final String text = unescape(unquote(ctx.getText(), '\"'));
             final StringExpression expr = new StringExpression(ctx.getStart(), text);
             log.trace("STRING: ctx {} => {}", ctx, expr);
             exprs.put(ctx, expr);
@@ -869,7 +874,7 @@ public class PipelineRuleParser {
 
         @Override
         public void exitString(RuleLangParser.StringContext ctx) {
-            final String text = unquote(ctx.getText(), '\"');
+            final String text = unescape(unquote(ctx.getText(), '\"'));
             final StringExpression expr = new StringExpression(ctx.getStart(), text);
             log.trace("STRING: ctx {} => {}", ctx, expr);
             parseContext.exprs.put(ctx, expr);

--- a/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -305,6 +305,8 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message).isNotNull();
         assertThat(message.getField("has_xyz")).isInstanceOf(Boolean.class);
         assertThat((boolean)message.getField("has_xyz")).isFalse();
+        assertThat(message.getField("string_literal")).isInstanceOf(String.class);
+        assertThat((String)message.getField("string_literal")).isEqualTo("abcd\\.e\tfg\u03a9\363");
     }
 
     @Test

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/regexMatch.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/regexMatch.txt
@@ -1,9 +1,8 @@
 rule "regexMatch"
 when
-// the second matcher group is always empty and will not be present in the result
-    regex(".*(cde)(:(\\d+))?.*", "abcdefg").matches == true
+    regex(".*(cde\\.)(:(\\d+))?.*", "abcde.fg").matches == true
 then
-    let result = regex(".*(cde).*", "abcdefg");
+    let result = regex(".*(cd\\.e).*", "abcd.efg");
     set_field("group_1", result["0"]);
     set_field("matched_regex", result.matches);
 end

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/strings.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/strings.txt
@@ -17,5 +17,6 @@ when
     concat("foo", "bar") == "foobar"
 then
     set_field("has_xyz", contains("abcdef", "xyz"));
+    set_field("string_literal", "abcd\\.e\tfg\u03a9\363");
     trigger_test();
 end


### PR DESCRIPTION
Pipeline rules use the same lexical structure as Java for string literals.

Before using the parsed string literals, we need to unescape them, removing double backslashes, otherwise the string will actually include two backslashes instead of one.

Fixes #46