### PR TITLE
Allow null matcher group values in regex function

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/RegexMatch.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/RegexMatch.java
@@ -97,6 +97,12 @@ public class RegexMatch extends AbstractFunction<RegexMatch.RegexMatchResult> {
                 final int groupCount = matchResult.groupCount();
                 for (int i = 1; i <= groupCount; i++) {
                     final String groupValue = matchResult.group(i);
+
+                    if (groupValue == null) {
+                        // You cannot add null values to an ImmutableMap but optional matcher groups may be null.
+                        continue;
+                    }
+
                     // try to get a group name, if that fails use a 0-based index as the name
                     final String groupName = Iterables.get(groupNames, i - 1, null);
                     builder.put(groupName != null ? groupName : String.valueOf(i - 1), groupValue);

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/regexMatch.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/regexMatch.txt
@@ -1,6 +1,7 @@
 rule "regexMatch"
 when
-    regex(".*(cde).*", "abcdefg").matches == true
+// the second matcher group is always empty and will not be present in the result
+    regex(".*(cde)(:(\\d+))?.*", "abcdefg").matches == true
 then
     let result = regex(".*(cde).*", "abcdefg");
     set_field("group_1", result["0"]);


### PR DESCRIPTION
Imagine you have a regular expression that is matching an IP address and a port. UDP and TCP will always have the port but ICMP will be missing the port.

The way to solve this is to have an optional matcher group that might match nothing in case of ICMP and end up with a null value in the matcher group results. 

The problem is that we are using a `ImmutableMap` to store the matcher group values and a `ImmutableMap` does not allow `null` as value. This means that the regex function will always fail in case of ICMP packages but the port matcher group has a `null` value.

This pull request avoids adding a `null` value to the `ImmutableMap`. The order of matchers is still intact because we use the group match name or index as key of the map.

I found and (hopefully) fixed and actual issue in the year 2016. (7/19 may we never forget)