### PR TITLE
add rename_field function

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -44,6 +44,7 @@ import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.DropMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.HasField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveField;
+import org.graylog.plugins.pipelineprocessor.functions.messages.RenameField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RouteToStream;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetFields;
@@ -78,6 +79,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(HasField.NAME, HasField.class);
         addMessageProcessorFunction(SetField.NAME, SetField.class);
         addMessageProcessorFunction(SetFields.NAME, SetFields.class);
+        addMessageProcessorFunction(RenameField.NAME, RenameField.class);
         addMessageProcessorFunction(RemoveField.NAME, RemoveField.class);
 
         addMessageProcessorFunction(DropMessage.NAME, DropMessage.class);

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/RenameField.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/RenameField.java
@@ -1,0 +1,54 @@
+package org.graylog.plugins.pipelineprocessor.functions.messages;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.graylog2.plugin.Message;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.type;
+
+public class RenameField extends AbstractFunction<Void> {
+
+    public static final String NAME = "rename_field";
+
+    private final ParameterDescriptor<String, String> oldFieldParam;
+    private final ParameterDescriptor<String, String> newFieldParam;
+    private final ParameterDescriptor<Message, Message> messageParam;
+
+    public RenameField() {
+        oldFieldParam = string("old_field").build();
+        newFieldParam = string("new_field").build();
+        messageParam = type("message", Message.class).optional().build();
+    }
+
+    @Override
+    public Void evaluate(FunctionArgs args, EvaluationContext context) {
+        final String oldName = oldFieldParam.required(args, context);
+        final String newName = newFieldParam.required(args, context);
+
+        // exit early if the field names are the same (so we don't drop the field)
+        if (oldName != null && oldName.equals(newName)) {
+            return null;
+        }
+        final Message message = messageParam.optional(args, context).orElse(context.currentMessage());
+
+        if (message.hasField(oldName)) {
+            message.addField(newName, message.getField(oldName));
+            message.removeField(oldName);
+        }
+
+        return null;
+    }
+
+    @Override
+    public FunctionDescriptor<Void> descriptor() {
+        return FunctionDescriptor.<Void>builder()
+                .name(NAME)
+                .returnType(Void.class)
+                .params(oldFieldParam, newFieldParam, messageParam)
+                .build();
+    }
+}

--- a/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -49,6 +49,7 @@ import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.DropMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.HasField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveField;
+import org.graylog.plugins.pipelineprocessor.functions.messages.RenameField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RouteToStream;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetFields;
@@ -113,6 +114,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(HasField.NAME, new HasField());
         functions.put(SetField.NAME, new SetField());
         functions.put(SetFields.NAME, new SetFields());
+        functions.put(RenameField.NAME, new RenameField());
         functions.put(RemoveField.NAME, new RemoveField());
 
         functions.put(DropMessage.NAME, new DropMessage());
@@ -451,5 +453,20 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         evaluateRule(rule, in);
 
         assertThat(actionsTriggered.get()).isFalse();
+    }
+
+    @Test
+    public void fieldRenaming() {
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+
+        final Message in = new Message("some message", "somehost.graylog.org", Tools.nowUTC());
+        in.addField("field_a", "fieldAContent");
+        in.addField("field_b", "not deleted");
+
+        final Message message = evaluateRule(rule, in);
+
+        assertThat(message.hasField("field_1")).isFalse();
+        assertThat(message.hasField("field_2")).isTrue();
+        assertThat(message.hasField("field_b")).isTrue();
     }
 }

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/fieldRenaming.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/fieldRenaming.txt
@@ -1,0 +1,8 @@
+rule "fieldRenaming"
+when true
+then
+
+    rename_field("no_such_field", "field_1");
+    rename_field("field_a", "field_2");
+    rename_field("field_b", "field_b");
+end


### PR DESCRIPTION
this is a convenience function which renames a field, if present.
it takes care not to drop fields if they are renamed to themselves

fixes #37