### PR TITLE
make conversion functions more consistent

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/StringConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/StringConversion.java
@@ -60,7 +60,7 @@ public class StringConversion extends AbstractFunction<String> {
     public String evaluate(FunctionArgs args, EvaluationContext context) {
         final Object evaluated = valueParam.required(args, context);
         if (evaluated == null) {
-            return null;
+            return defaultParam.optional(args, context).orElse("");
         }
         // fast path for the most common targets
         if (evaluated instanceof String

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddress.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddress.java
@@ -20,6 +20,7 @@ import com.google.common.net.InetAddresses;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Objects;
 
 /**
  * Graylog's rule language wrapper for InetAddress.
@@ -56,5 +57,18 @@ public class IpAddress {
             // cannot happen, it's created from a valid InetAddress to begin with
             throw new IllegalStateException(e);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof IpAddress)) return false;
+        IpAddress ipAddress = (IpAddress) o;
+        return Objects.equals(address, ipAddress.address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(address);
     }
 }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddressConversion.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddressConversion.java
@@ -32,6 +32,8 @@ import static com.google.common.collect.ImmutableList.of;
 public class IpAddressConversion extends AbstractFunction<IpAddress> {
 
     public static final String NAME = "to_ip";
+    private static final InetAddress ANYV4 = InetAddresses.forString("0.0.0.0");
+
     private final ParameterDescriptor<Object, Object> ipParam;
     private final ParameterDescriptor<String, String> defaultParam;
 
@@ -50,7 +52,7 @@ public class IpAddressConversion extends AbstractFunction<IpAddress> {
         } catch (IllegalArgumentException e) {
             final Optional<String> defaultValue = defaultParam.optional(args, context);
             if (!defaultValue.isPresent()) {
-                return null;
+                return new IpAddress(ANYV4);
             }
             try {
                 return new IpAddress(InetAddresses.forString(defaultValue.get()));

--- a/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
+import com.google.common.net.InetAddresses;
 import org.graylog.plugins.pipelineprocessor.BaseParserTest;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
@@ -42,6 +43,7 @@ import org.graylog.plugins.pipelineprocessor.functions.hashing.SHA1;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.SHA256;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.SHA512;
 import org.graylog.plugins.pipelineprocessor.functions.ips.CidrMatch;
+import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddress;
 import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
@@ -468,5 +470,44 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.hasField("field_1")).isFalse();
         assertThat(message.hasField("field_2")).isTrue();
         assertThat(message.hasField("field_b")).isTrue();
+    }
+
+    @Test
+    public void conversions() {
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+
+        final EvaluationContext context = contextForRuleEval(rule, new Message("test", "test", Tools.nowUTC()));
+
+        assertThat(context.evaluationErrors()).isEmpty();
+        final Message message = context.currentMessage();
+
+        assertNotNull(message);
+        assertThat(message.getField("string_1")).isEqualTo("1");
+        assertThat(message.getField("string_2")).isEqualTo("2");
+        // special case, Message doesn't allow adding fields with empty string values
+        assertThat(message.hasField("string_3")).isFalse();
+        assertThat(message.getField("string_4")).isEqualTo("default");
+
+        assertThat(message.getField("long_1")).isEqualTo(1L);
+        assertThat(message.getField("long_2")).isEqualTo(2L);
+        assertThat(message.getField("long_3")).isEqualTo(0L);
+        assertThat(message.getField("long_4")).isEqualTo(1L);
+
+        assertThat(message.getField("double_1")).isEqualTo(1d);
+        assertThat(message.getField("double_2")).isEqualTo(2d);
+        assertThat(message.getField("double_3")).isEqualTo(0d);
+        assertThat(message.getField("double_4")).isEqualTo(1d);
+
+        assertThat(message.getField("bool_1")).isEqualTo(true);
+        assertThat(message.getField("bool_2")).isEqualTo(false);
+        assertThat(message.getField("bool_3")).isEqualTo(false);
+        assertThat(message.getField("bool_4")).isEqualTo(true);
+
+        // the is wrapped in our own class for safey in rules
+        assertThat(message.getField("ip_1")).isEqualTo(new IpAddress(InetAddresses.forString("127.0.0.1")));
+        assertThat(message.getField("ip_2")).isEqualTo(new IpAddress(InetAddresses.forString("127.0.0.1")));
+        assertThat(message.getField("ip_3")).isEqualTo(new IpAddress(InetAddresses.forString("0.0.0.0")));
+        assertThat(message.getField("ip_4")).isEqualTo(new IpAddress(InetAddresses.forString("::1")));
+
     }
 }

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/conversions.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/conversions.txt
@@ -1,0 +1,30 @@
+rule "conversions"
+when true
+then
+    set_fields({
+        string_1: to_string("1"),                           // "1"
+        string_2: to_string("2", "default"),                // "2"
+        string_3: to_string($message.not_there),            // "" -> not being set in message!
+        string_4: to_string($message.not_there, "default"), // "default"
+
+        long_1: to_long(1),                     // 1L
+        long_2: to_long(2, 1),                  // 2L
+        long_3: to_long($message.not_there),    // 0L
+        long_4: to_long($message.not_there, 1), // 1L
+
+        double_1: to_double(1d),                        // 1d
+        double_2: to_double(2d, 1d),                    // 2d
+        double_3: to_double($message.not_there),        // 0d
+        double_4: to_double($message.not_there, 1d),    // 1d
+
+        bool_1: to_bool("true"),                      // true
+        bool_2: to_bool("false", true),               // false
+        bool_3: to_bool($message.not_there),          // false
+        bool_4: to_bool($message.not_there, true),    // true
+
+        ip_1: to_ip("127.0.0.1"),                 // 127.0.0.1
+        ip_2: to_ip("127.0.0.1", "2001:db8::1"),  // 127.0.0.1
+        ip_3: to_ip($message.not_there),          // 0.0.0.0
+        ip_4: to_ip($message.not_there, "::1")    // ::1 (v6)
+    });
+end


### PR DESCRIPTION
 * there was a bug with to_string returning null instead of its default value (refs #63)
 * all core conversion functions now return their "default empty" value if the value is `null`
   - String: ""
   - bool: false
   - double: 0d
   - long 0L
   - IP: V4 ANY (0.0.0.0)
 * adds test cases for all cases, including the edge cases