### PR TITLE
support "only named captures" for pipeline grok function

### DIFF
--- a/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -183,7 +183,8 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         Set<GrokPattern> patterns = Sets.newHashSet(
                 GrokPattern.create("GREEDY", ".*"),
                 GrokPattern.create("BASE10NUM", "(?<![0-9.+-])(?>[+-]?(?:(?:[0-9]+(?:\\.[0-9]+)?)|(?:\\.[0-9]+)))"),
-                GrokPattern.create("NUMBER", "(?:%{BASE10NUM:UNWANTED})")
+                GrokPattern.create("NUMBER", "(?:%{BASE10NUM:UNWANTED})"),
+                GrokPattern.create("NUM", "%{BASE10NUM}")
         );
         when(grokPatternService.loadAll()).thenReturn(patterns);
         final EventBus clusterBus = new EventBus();
@@ -370,8 +371,11 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         final Message message = evaluateRule(rule);
 
         assertThat(message).isNotNull();
-        assertThat(message.getFieldCount()).isEqualTo(4);
+        assertThat(message.getFieldCount()).isEqualTo(5);
         assertThat(message.getTimestamp()).isEqualTo(DateTime.parse("2015-07-31T10:05:36.773Z"));
+        // named captures only
+        assertThat(message.hasField("num")).isTrue();
+        assertThat(message.hasField("BASE10NUM")).isFalse();
     }
 
     @Test

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/grok.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/grok.txt
@@ -3,4 +3,8 @@ when true
 then
     let matches = grok(pattern: "%{GREEDY:timestamp;date;yyyy-MM-dd'T'HH:mm:ss.SSSX}", value: "2015-07-31T10:05:36.773Z");
     set_fields(matches);
+
+    // only named captures
+    let matches1 = grok("%{NUM:num}", "10", true);
+    set_fields(matches1);
 end


### PR DESCRIPTION
the server cache is necessary because the named captures support needs a separately compiled regex
so far the cache is only used by the grok function in the pipeline processor

fixes Graylog2/graylog-plugin-pipeline-processor#59