### PR TITLE
fix tests after conversion function unification

### DIFF
--- a/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -86,7 +86,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Map;
@@ -329,19 +328,6 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    @Ignore("Failing after merging https://github.com/Graylog2/graylog-plugin-pipeline-processor/pull/64")
-    public void evalError() {
-        final Rule rule = parser.parseRule(ruleForTest(), false);
-
-        final EvaluationContext context = contextForRuleEval(rule, new Message("test", "test", Tools.nowUTC()));
-
-        assertThat(context).isNotNull();
-        assertThat(context.hasEvaluationErrors()).isTrue();
-        assertThat(Iterables.getLast(context.evaluationErrors()).toString()).isEqualTo("In call to function 'regex' at 5:28 an exception was thrown: Argument 'value' cannot be 'null'");
-    }
-
-    @Test
-    @Ignore("Failing after merging https://github.com/Graylog2/graylog-plugin-pipeline-processor/pull/64")
     public void evalErrorSuppressed() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
 

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/evalError.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/evalError.txt
@@ -1,6 +1,0 @@
-rule "trigger null"
-when
-  true
-then
-  set_field("do_not_exist", regex(".*", to_string($message.do_not_exist)).matches);
-end

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/evalErrorSuppressed.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/evalErrorSuppressed.txt
@@ -1,6 +1,6 @@
 rule "suppressing exceptions/nulls"
 when
-    is_null(to_ip($message.does_not_exist)) && is_not_null($message.this_field_was_set)
+    is_null(to_ip($message.does_not_exist, "d.f.f.f")) && is_not_null($message.this_field_was_set)
 then
     trigger_test();
 end


### PR DESCRIPTION
evalError can no longer trigger the error tested for, removed
evalErrorSuppressed now tests an illegal default value in to_ip

fixes #69