### PR TITLE
remote wildcard type cast to make intellij 2016.2 happy

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/SelectJsonPath.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/SelectJsonPath.java
@@ -54,8 +54,8 @@ public class SelectJsonPath extends AbstractFunction<Map<String, Object>> {
         // sigh generics and type erasure
         //noinspection unchecked
         pathsParam = ParameterDescriptor.type("paths",
-                                              (Class<? extends Map<String, String>>) new TypeLiteral<Map<String, String>>() {}.getRawType(),
-                                              (Class<? extends Map<String, JsonPath>>) new TypeLiteral<Map<String, JsonPath>>() {}.getRawType())
+                                              (Class<Map<String, String>>) new TypeLiteral<Map<String, String>>() {}.getRawType(),
+                                              (Class<Map<String, JsonPath>>) new TypeLiteral<Map<String, JsonPath>>() {}.getRawType())
                 .transform(inputMap -> inputMap
                         .entrySet().stream()
                         .collect(toMap(Map.Entry::getKey, e -> JsonPath.compile(e.getValue()))))


### PR DESCRIPTION
this change should not affect javac at all, but intellij flags the collect call with having two errors