### PR TITLE
Allow selection of an input ID for the simulation message

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/FromInput.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/FromInput.java
@@ -72,7 +72,7 @@ public class FromInput extends AbstractFunction<Boolean> {
 
         }
         return input != null
-                && context.currentMessage().getSourceInputId().equals(input.getId());
+                && input.getId().equals(context.currentMessage().getSourceInputId());
     }
 
     @Override

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulationRequest.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulationRequest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 @AutoValue
@@ -32,16 +33,22 @@ public abstract class SimulationRequest {
     @JsonProperty
     public abstract Map<String, Object> message();
 
+    @JsonProperty
+    @Nullable
+    public abstract String inputId();
+
     public static Builder builder() {
         return new AutoValue_SimulationRequest.Builder();
     }
 
     @JsonCreator
     public static SimulationRequest create (@JsonProperty("stream_id") String streamId,
-                                            @JsonProperty("message") Map<String, Object> message) {
+                                            @JsonProperty("message") Map<String, Object> message,
+                                            @JsonProperty("input_id") @Nullable String inputId) {
         return builder()
                 .streamId(streamId)
                 .message(message)
+                .inputId(inputId)
                 .build();
     }
 
@@ -52,5 +59,7 @@ public abstract class SimulationRequest {
         public abstract Builder streamId(String streamId);
 
         public abstract Builder message(Map<String, Object> message);
+
+        public abstract Builder inputId(String inputId);
     }
 }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
@@ -21,6 +21,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.elasticsearch.common.Strings;
 import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
 import org.graylog.plugins.pipelineprocessor.simulator.PipelineInterpreterTracer;
 import org.graylog2.database.NotFoundException;
@@ -68,6 +69,9 @@ public class SimulatorResource extends RestResource implements PluginRestResourc
         if (!request.streamId().equals("default")) {
             final Stream stream = streamService.load(request.streamId());
             message.addStream(stream);
+        }
+        if (!Strings.isNullOrEmpty(request.inputId())) {
+            message.setSourceInputId(request.inputId());
         }
 
         final List<ResultMessageSummary> simulationResults = new ArrayList<>();

--- a/src/web/simulator/ProcessorSimulator.jsx
+++ b/src/web/simulator/ProcessorSimulator.jsx
@@ -22,11 +22,11 @@ const ProcessorSimulator = React.createClass({
     };
   },
 
-  _onMessageLoad(message) {
+  _onMessageLoad(message, options) {
     this.setState({ message: message, simulation: undefined, loading: true, error: undefined });
 
     SimulatorActions.simulate
-      .triggerPromise(this.props.stream, message.fields)
+      .triggerPromise(this.props.stream, message.fields, options.inputId)
       .then(
         response => {
           this.setState({ simulation: response, loading: false });
@@ -47,7 +47,7 @@ const ProcessorSimulator = React.createClass({
               Build an example message that will be used in the simulation.{' '}
               <strong>No real messages stored in Graylog will be changed. All actions are purely simulated on the temporary input you provide below.</strong>
             </p>
-            <RawMessageLoader onMessageLoaded={this._onMessageLoad} />
+            <RawMessageLoader onMessageLoaded={this._onMessageLoad} inputIdSelector />
           </Col>
         </Row>
         <SimulationResults stream={this.props.stream}

--- a/src/web/simulator/SimulatorStore.js
+++ b/src/web/simulator/SimulatorStore.js
@@ -12,11 +12,12 @@ const urlPrefix = '/plugins/org.graylog.plugins.pipelineprocessor';
 const SimulatorStore = Reflux.createStore({
   listenables: [SimulatorActions],
 
-  simulate(stream, messageFields) {
+  simulate(stream, messageFields, inputId) {
     const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/simulate`);
     const simulation = {
       stream_id: stream.id,
       message: messageFields,
+      input_id: inputId,
     };
 
     let promise = fetch('POST', url, simulation);


### PR DESCRIPTION
1. Invert equals() call to avoid possible null pointer exception.
    Fixes Graylog2/graylog2-server#2610
1. Pipeline rules may use the `from_input` function in a condition so this
is needed to make the simulation work.
    Refs Graylog2/graylog2-server#2610