### PR TITLE
Unregister PipelineInterpreter from event bus

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
@@ -17,7 +17,6 @@
 package org.graylog.plugins.pipelineprocessor;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.assistedinject.Assisted;
@@ -122,6 +121,8 @@ public class PipelineProcessorMessageDecorator implements SearchResponseDecorato
                 ));
             });
         });
+
+        pipelineInterpreter.stop();
 
         return searchResponse.toBuilder().messages(results).build();
     }

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
@@ -82,6 +82,8 @@ public class SimulatorResource extends RestResource implements PluginRestResourc
         for (Message processedMessage : processedMessages) {
             simulationResults.add(ResultMessageSummary.create(null, processedMessage.getFields(), ""));
         }
+
+        pipelineInterpreter.stop();
         return SimulationResponse.create(simulationResults,
                                          pipelineInterpreterTracer.getExecutionTrace(),
                                          pipelineInterpreterTracer.took());


### PR DESCRIPTION
Message decorators and the pipeline simulator create new instances of `PipelineInterpreter`s that never get garbage collected, as they are still registered in the event bus.

These changes add a simple workaround for that. We should probably refactor the lifecycle of the `PipelineInterpreter`, but this is probably not the best time to do it.