### PR TITLE
Use find in the regex function

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/RegexMatch.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/RegexMatch.java
@@ -60,7 +60,7 @@ public class RegexMatch extends AbstractFunction<RegexMatch.RegexMatchResult> {
                 (List<String>) optionalGroupNames.optional(args, context).orElse(Collections.emptyList());
 
         final Matcher matcher = regex.matcher(value);
-        final boolean matches = matcher.matches();
+        final boolean matches = matcher.find();
 
         return new RegexMatchResult(matches, matcher.toMatchResult(), groupNames);
 

--- a/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -299,6 +299,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
             assertNotNull(message);
             assertTrue(message.hasField("matched_regex"));
             assertTrue(message.hasField("group_1"));
+            assertThat((String) message.getField("named_group")).isEqualTo("cd.e");
         } catch (ParseException e) {
             Assert.fail("Should parse");
         }

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/regexMatch.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/regexMatch.txt
@@ -1,8 +1,13 @@
 rule "regexMatch"
 when
-    regex(".*(cde\\.)(:(\\d+))?.*", "abcde.fg").matches == true
+    regex("^.*(cde\\.)(:(\\d+))?.*$", "abcde.fg").matches == true &&
+    regex(".*(cde\\.)(:(\\d+))?.*", "abcde.fg").matches == true &&
+    regex("(cde\\.)(:(\\d+))?", "abcde.fg").matches == true &&
+    regex("^(cde\\.)(:(\\d+))?$", "abcde.fg").matches == false
 then
-    let result = regex(".*(cd\\.e).*", "abcd.efg");
+    let result = regex("(cd\\.e)", "abcd.efg");
     set_field("group_1", result["0"]);
+    let result = regex("(cd\\.e)", "abcd.efg", ["name"]);
+    set_field("named_group", result["name"]);
     set_field("matched_regex", result.matches);
 end


### PR DESCRIPTION
Do not force regular expressions passed to `regex()` to match the whole string, switching from `Matcher.match()` to `Matcher.find()`.

Fixes #35