### PR TITLE
Fix page size in function list

### DIFF
--- a/src/web/rules/RuleHelper.jsx
+++ b/src/web/rules/RuleHelper.jsx
@@ -111,7 +111,7 @@ end`,
       return <Spinner />;
     }
 
-    const pagedEntries = this.state.functionDescriptors.slice((this.state.currentPage - 1) * this.state.pageSize, (this.state.currentPage * this.state.pageSize) - 1);
+    const pagedEntries = this.state.functionDescriptors.slice((this.state.currentPage - 1) * this.state.pageSize, this.state.currentPage * this.state.pageSize);
 
     return (
       <Panel header="Rules quick reference">


### PR DESCRIPTION
`slice()` doesn't include the end element in the array that returns, so we were rendering 9 functions instead of 10.