### PR TITLE
use case insensitive lookup for timezone IDs

### DIFF
--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/TimezoneAwareFunction.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/TimezoneAwareFunction.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.pipelineprocessor.functions.dates;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
@@ -25,15 +26,22 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import java.util.Locale;
+
 public abstract class TimezoneAwareFunction extends AbstractFunction<DateTime> {
 
-    public static final String TIMEZONE = "timezone";
+    private static final String TIMEZONE = "timezone";
+    private static final com.google.common.collect.ImmutableMap<String, String> UPPER_ZONE_MAP = Maps.uniqueIndex(
+            DateTimeZone.getAvailableIDs(),
+            input -> input != null ? input.toUpperCase(Locale.ENGLISH) : "UTC");
     private final ParameterDescriptor<String, DateTimeZone> timeZoneParam;
 
-    public TimezoneAwareFunction() {
+    protected TimezoneAwareFunction() {
+        DateTimeZone.getAvailableIDs();
+
         timeZoneParam = ParameterDescriptor
                 .string(TIMEZONE, DateTimeZone.class)
-                .transform(id -> DateTimeZone.forID(id.toUpperCase()))
+                .transform(id -> DateTimeZone.forID(UPPER_ZONE_MAP.get(id)))
                 .optional()
                 .description("The timezone to apply to the date, defaults to UTC")
                 .build();

--- a/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/TimezoneAwareFunction.java
+++ b/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/TimezoneAwareFunction.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.pipelineprocessor.functions.dates;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
@@ -31,14 +32,12 @@ import java.util.Locale;
 public abstract class TimezoneAwareFunction extends AbstractFunction<DateTime> {
 
     private static final String TIMEZONE = "timezone";
-    private static final com.google.common.collect.ImmutableMap<String, String> UPPER_ZONE_MAP = Maps.uniqueIndex(
+    private static final ImmutableMap<String, String> UPPER_ZONE_MAP = Maps.uniqueIndex(
             DateTimeZone.getAvailableIDs(),
             input -> input != null ? input.toUpperCase(Locale.ENGLISH) : "UTC");
     private final ParameterDescriptor<String, DateTimeZone> timeZoneParam;
 
     protected TimezoneAwareFunction() {
-        DateTimeZone.getAvailableIDs();
-
         timeZoneParam = ParameterDescriptor
                 .string(TIMEZONE, DateTimeZone.class)
                 .transform(id -> DateTimeZone.forID(UPPER_ZONE_MAP.get(id)))

--- a/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -562,4 +562,12 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
         assertThat(context.hasEvaluationErrors()).isTrue();
     }
+
+    @Test
+    public void timezones() {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        evaluateRule(rule);
+
+        assertThat(actionsTriggered.get()).isTrue();
+    }
 }

--- a/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -565,9 +565,15 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
     @Test
     public void timezones() {
-        final Rule rule = parser.parseRule(ruleForTest(), true);
-        evaluateRule(rule);
+        final InstantMillisProvider clock = new InstantMillisProvider(GRAYLOG_EPOCH);
+        DateTimeUtils.setCurrentMillisProvider(clock);
+        try {
+            final Rule rule = parser.parseRule(ruleForTest(), true);
+            evaluateRule(rule);
 
-        assertThat(actionsTriggered.get()).isTrue();
+            assertThat(actionsTriggered.get()).isTrue();
+        } finally {
+            DateTimeUtils.setCurrentMillisSystem();
+        }
     }
 }

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/timezones.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/timezones.txt
@@ -5,7 +5,7 @@ when
   now("CET") == now("UTC") &&
   now("utc") == now("UTC") &&
   now("Europe/Moscow") == now("europe/moscow") &&
-  now("europe/MoSCOw") == now("+03")
+  now("europe/MoSCOw") == now("msk")
 then
   trigger_test();
 end

--- a/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/timezones.txt
+++ b/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/timezones.txt
@@ -1,0 +1,11 @@
+// now() is fixed, test uses different millisprovider!
+
+rule "timezones"
+when
+  now("CET") == now("UTC") &&
+  now("utc") == now("UTC") &&
+  now("Europe/Moscow") == now("europe/moscow") &&
+  now("europe/MoSCOw") == now("+03")
+then
+  trigger_test();
+end


### PR DESCRIPTION
simply upper-casing timezone IDs failed for strings like 'Europe/Moscow'. Unfortunately the forID function is case sensitive.

fixes #100