### PR TITLE
Interpreter performance

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -104,7 +104,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
         <jmh.version>1.14.1</jmh.version>
         <javac.target>1.8</javac.target>
         <uberjar.name>pipeline-benchmarks-${git.commit.id.describe}</uberjar.name>
-        <graylog.version>${graylog.version}</graylog.version>
+        <graylog.version>2.2.0-alpha.4-SNAPSHOT</graylog.version>
     </properties>
 
     <build>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -103,8 +103,8 @@ THE POSSIBILITY OF SUCH DAMAGE.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jmh.version>1.14.1</jmh.version>
         <javac.target>1.8</javac.target>
-        <uberjar.name>pipeline-benchmarks</uberjar.name>
-        <graylog.version>2.2.0-alpha.2-SNAPSHOT</graylog.version>
+        <uberjar.name>pipeline-benchmarks-${git.commit.id.describe}</uberjar.name>
+        <graylog.version>${graylog.version}</graylog.version>
     </properties>
 
     <build>

--- a/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/PipelinePerformanceBenchmarks.java
+++ b/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/PipelinePerformanceBenchmarks.java
@@ -74,6 +74,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -524,6 +525,7 @@ public class PipelinePerformanceBenchmarks {
                 .forks(forks)
                 .param("directoryName", benchmarkParams)
                 .jvmArgsAppend("-DbenchmarkDir="+benchmarkDir)
+                .resultFormat(ResultFormatType.CSV)
                 .build();
 
         final Runner runner = new Runner(opt);

--- a/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/PipelinePerformanceBenchmarks.java
+++ b/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/PipelinePerformanceBenchmarks.java
@@ -73,6 +73,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -89,6 +90,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -517,13 +519,15 @@ public class PipelinePerformanceBenchmarks {
                 .warmupTime(TimeValue.seconds(5))
                 .measurementIterations(iterations)
                 .measurementTime(TimeValue.seconds(20))
+                .detectJvmArgs()
                 .threads(1)
                 .forks(forks)
                 .param("directoryName", benchmarkParams)
                 .jvmArgsAppend("-DbenchmarkDir="+benchmarkDir)
                 .build();
 
-        new Runner(opt).run();
+        final Runner runner = new Runner(opt);
+        final Collection<RunResult> results = runner.run();
     }
 
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -61,7 +61,7 @@
             <dependency>
                 <groupId>com.google.auto.value</groupId>
                 <artifactId>auto-value</artifactId>
-                <version>1.4-SNAPSHOT</version>
+                <version>1.4-rc1</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -61,7 +61,7 @@
             <dependency>
                 <groupId>com.google.auto.value</groupId>
                 <artifactId>auto-value</artifactId>
-                <version>${auto-value.version}</version>
+                <version>1.4-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/Pipeline.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/Pipeline.java
@@ -33,10 +33,6 @@ public abstract class Pipeline {
     private String metricName;
     private transient Meter executed;
 
-    public Pipeline() {
-        ;
-    }
-
     @Nullable
     public abstract String id();
     public abstract String name();

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/Pipeline.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/Pipeline.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.pipelineprocessor.ast;
 
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.collect.Sets;
 
 import javax.annotation.Nullable;
@@ -43,6 +44,9 @@ public abstract class Pipeline {
     public Pipeline withId(String id) {
         return toBuilder().id(id).build();
     }
+
+    @Memoized
+    public abstract int hashCode();
 
     @AutoValue.Builder
     public abstract static class Builder {

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/Stage.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/Stage.java
@@ -29,6 +29,8 @@ import static com.codahale.metrics.MetricRegistry.name;
 @AutoValue
 public abstract class Stage implements Comparable<Stage> {
     private List<Rule> rules;
+    // not an autovalue property, because it introduces a cycle in hashCode() and we have no way of excluding it
+    private transient Pipeline pipeline;
     private transient Meter executed;
     private transient String meterName;
 
@@ -82,6 +84,14 @@ public abstract class Stage implements Comparable<Stage> {
         if (executed != null) {
             executed.mark();
         }
+    }
+
+    public Pipeline getPipeline() {
+        return pipeline;
+    }
+
+    public void setPipeline(Pipeline pipeline) {
+        this.pipeline = pipeline;
     }
 
     @AutoValue.Builder

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.pipelineprocessor.parser;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -85,14 +86,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.Stack;
 
+import static com.google.common.collect.ImmutableSortedSet.orderedBy;
+import static java.util.Comparator.comparingInt;
 import static java.util.stream.Collectors.toList;
 
 public class PipelineRuleParser {
@@ -905,7 +906,7 @@ public class PipelineRuleParser {
             final Pipeline.Builder builder = Pipeline.builder();
 
             builder.name(unquote(ctx.name.getText(), '"'));
-            SortedSet<Stage> stages = Sets.newTreeSet(Comparator.comparingInt(Stage::stage));
+            final ImmutableSortedSet.Builder<Stage> stages = orderedBy(comparingInt(Stage::stage));
 
             for (RuleLangParser.StageDeclarationContext stage : ctx.stageDeclaration()) {
                 final Stage.Builder stageBuilder = Stage.builder();
@@ -942,7 +943,7 @@ public class PipelineRuleParser {
                 stages.add(stageBuilder.build());
             }
 
-            builder.stages(stages);
+            builder.stages(stages.build());
             parseContext.pipelines.add(builder.build());
         }
 

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -245,7 +245,7 @@ public class PipelineInterpreter implements MessageProcessor {
                     log.debug("[{}] running pipelines {} for streams {}", msgId, pipelinesToRun, streamsIds);
                 }
 
-                toProcess.addAll(processForPipelines(message, msgId, pipelinesToRun.stream().map(Pipeline::id).collect(Collectors.toSet()), interpreterListener));
+                toProcess.addAll(processForResolvedPipelines(message, msgId, pipelinesToRun, interpreterListener));
 
                 boolean addedStreams = false;
                 // 5. add each message-stream combination to the blacklist set
@@ -291,7 +291,10 @@ public class PipelineInterpreter implements MessageProcessor {
         return processForResolvedPipelines(message, msgId, pipelinesToRun, interpreterListener);
     }
 
-    public List<Message> processForResolvedPipelines(Message message, String msgId, Set<Pipeline> pipelines, InterpreterListener interpreterListener) {
+    private List<Message> processForResolvedPipelines(Message message,
+                                                      String msgId,
+                                                      Set<Pipeline> pipelines,
+                                                      InterpreterListener interpreterListener) {
         final List<Message> result = new ArrayList<>();
         // record execution of pipeline in metrics
         pipelines.forEach(pipeline -> metricRegistry.counter(name(Pipeline.class, pipeline.id(), "executed")).inc());

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -185,6 +185,7 @@ public class PipelineInterpreter implements MessageProcessor {
                     })
                     .collect(Collectors.toList());
             stage.setRules(resolvedRules);
+            stage.setPipeline(pipeline);
             stage.registerMetrics(metricRegistry, pipeline.id());
         });
 
@@ -314,10 +315,9 @@ public class PipelineInterpreter implements MessageProcessor {
         // iterate through all stages for all matching pipelines, per "stage slice" instead of per pipeline.
         // pipeline execution ordering is not guaranteed
         while (stages.hasNext()) {
-            final Set<Tuple2<Stage, Pipeline>> stageSet = stages.next();
-            for (Tuple2<Stage, Pipeline> pair : stageSet) {
-                final Stage stage = pair.v1();
-                final Pipeline pipeline = pair.v2();
+            final List<Stage> stageSet = stages.next();
+            for (final Stage stage : stageSet) {
+                final Pipeline pipeline = stage.getPipeline();
                 if (pipelinesToSkip.contains(pipeline)) {
                     log.debug("[{}] previous stage result prevents further processing of pipeline `{}`",
                              msgId,

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/StageIterator.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/StageIterator.java
@@ -23,6 +23,7 @@ import org.graylog.plugins.pipelineprocessor.ast.Stage;
 
 import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
 
 public class StageIterator extends AbstractIterator<List<Stage>> {
 
@@ -42,17 +43,14 @@ public class StageIterator extends AbstractIterator<List<Stage>> {
         }
         pipelines.forEach(pipeline -> {
             // skip pipelines without any stages, they don't contribute any rules to run
-            if (pipeline.stages().isEmpty()) {
+            final SortedSet<Stage> stages = pipeline.stages();
+            if (stages.isEmpty()) {
                 return;
             }
-            extent[0] = Math.min(extent[0], pipeline.stages().first().stage());
-            extent[1] = Math.max(extent[1], pipeline.stages().last().stage());
+            extent[0] = Math.min(extent[0], stages.first().stage());
+            extent[1] = Math.max(extent[1], stages.last().stage());
+            stages.forEach(stage -> stageMultimap.put(stage.stage(), stage));
         });
-
-        // map each stage number to the corresponding stages
-        pipelines.stream()
-                .flatMap(pipeline -> pipeline.stages().stream())
-                .forEach(stage -> stageMultimap.put(stage.stage(), stage));
 
         if (extent[0] == Integer.MIN_VALUE) {
             throw new IllegalArgumentException("First stage cannot be at " + Integer.MIN_VALUE);

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -16,19 +16,25 @@
  */
 package org.graylog.plugins.pipelineprocessor.processors;
 
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
+import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
+import org.graylog.plugins.pipelineprocessor.ast.Rule;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
-import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineStreamConnectionsService;
-import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbRuleService;
-import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineService;
 import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
 import org.graylog.plugins.pipelineprocessor.db.PipelineService;
 import org.graylog.plugins.pipelineprocessor.db.PipelineStreamConnectionsService;
 import org.graylog.plugins.pipelineprocessor.db.RuleDao;
 import org.graylog.plugins.pipelineprocessor.db.RuleService;
+import org.graylog.plugins.pipelineprocessor.db.memory.InMemoryPipelineService;
+import org.graylog.plugins.pipelineprocessor.db.memory.InMemoryPipelineStreamConnectionsService;
+import org.graylog.plugins.pipelineprocessor.db.memory.InMemoryRuleService;
+import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineService;
+import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineStreamConnectionsService;
+import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbRuleService;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
@@ -42,9 +48,12 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.SortedMap;
 import java.util.concurrent.Executors;
 
+import static com.codahale.metrics.MetricRegistry.name;
 import static com.google.common.collect.Sets.newHashSet;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -78,10 +87,11 @@ public class PipelineInterpreterTest {
                                    null)
         ));
 
-        final PipelineStreamConnectionsService pipelineStreamConnectionsService = mock(MongoDbPipelineStreamConnectionsService.class);
+        final PipelineStreamConnectionsService pipelineStreamConnectionsService = mock(
+                MongoDbPipelineStreamConnectionsService.class);
         final PipelineConnections pipelineConnections = PipelineConnections.create(null,
-                                                                                                  "default",
-                                                                                                  newHashSet("cde"));
+                                                                                   "default",
+                                                                                   newHashSet("cde"));
         when(pipelineStreamConnectionsService.loadAll()).thenReturn(
                 newHashSet(pipelineConnections)
         );
@@ -108,6 +118,97 @@ public class PipelineInterpreterTest {
 
         final Message[] messages = Iterables.toArray(processed, Message.class);
         assertEquals(2, messages.length);
+    }
+
+    @Test
+    public void testMetrics() {
+        final RuleService ruleService = new InMemoryRuleService();
+        ruleService.save(RuleDao.create("abc",
+                                        "title",
+                                        "description",
+                                        "rule \"match_all\"\n" +
+                                                "when true\n" +
+                                                "then\n" +
+                                                "end",
+                                        Tools.nowUTC(),
+                                        null)
+        );
+
+        final PipelineService pipelineService = new InMemoryPipelineService();
+        pipelineService.save(PipelineDao.create("cde", "title", "description",
+                                                "pipeline \"pipeline\"\n" +
+                                                        "stage 0 match all\n" +
+                                                        "    rule \"match_all\";\n" +
+                                                        "stage 1 match all\n" +
+                                                        "    rule \"match_all\";\n" +
+                                                        "end\n",
+                                                Tools.nowUTC(),
+                                                null)
+        );
+
+        final PipelineStreamConnectionsService pipelineStreamConnectionsService = new InMemoryPipelineStreamConnectionsService();
+        pipelineStreamConnectionsService.save(PipelineConnections.create(null,
+                                                                         "default",
+                                                                         newHashSet("cde")));
+
+        final Map<String, Function<?>> functions = Maps.newHashMap();
+
+        final PipelineRuleParser parser = setupParser(functions);
+
+        final MetricRegistry metricRegistry = new MetricRegistry();
+        final PipelineInterpreter interpreter = new PipelineInterpreter(
+                ruleService,
+                pipelineService,
+                pipelineStreamConnectionsService,
+                parser,
+                mock(Journal.class),
+                metricRegistry,
+                Executors.newScheduledThreadPool(1),
+                mock(EventBus.class)
+        );
+
+        interpreter.process(new Message("", "", Tools.nowUTC()));
+
+        final SortedMap<String, Meter> meters = metricRegistry.getMeters((name, metric) -> name.startsWith(name(Pipeline.class, "cde")) || name.startsWith(name(Rule.class, "abc")));
+
+        assertThat(meters.keySet()).containsExactlyInAnyOrder(
+                name(Pipeline.class, "cde", "executed"),
+                name(Pipeline.class, "cde", "stage", "0", "executed"),
+                name(Pipeline.class, "cde", "stage", "1", "executed"),
+                name(Rule.class, "abc", "executed"),
+                name(Rule.class, "abc", "cde", "0", "executed"),
+                name(Rule.class, "abc", "cde", "1", "executed"),
+                name(Rule.class, "abc", "matched"),
+                name(Rule.class, "abc", "cde", "0", "matched"),
+                name(Rule.class, "abc", "cde", "1", "matched"),
+                name(Rule.class, "abc", "not-matched"),
+                name(Rule.class, "abc", "cde", "0", "not-matched"),
+                name(Rule.class, "abc", "cde", "1", "not-matched"),
+                name(Rule.class, "abc", "failed"),
+                name(Rule.class, "abc", "cde", "0", "failed"),
+                name(Rule.class, "abc", "cde", "1", "failed")
+        );
+
+        assertThat(meters.get(name(Pipeline.class, "cde", "executed")).getCount()).isEqualTo(1L);
+        assertThat(meters.get(name(Pipeline.class, "cde", "stage", "0", "executed")).getCount()).isEqualTo(1L);
+        assertThat(meters.get(name(Pipeline.class, "cde", "stage", "1", "executed")).getCount()).isEqualTo(1L);
+
+        assertThat(meters.get(name(Rule.class, "abc", "executed")).getCount()).isEqualTo(2L);
+        assertThat(meters.get(name(Rule.class, "abc", "cde", "0", "executed")).getCount()).isEqualTo(1L);
+        assertThat(meters.get(name(Rule.class, "abc", "cde", "1", "executed")).getCount()).isEqualTo(1L);
+
+        assertThat(meters.get(name(Rule.class, "abc", "matched")).getCount()).isEqualTo(2L);
+        assertThat(meters.get(name(Rule.class, "abc", "cde", "0", "matched")).getCount()).isEqualTo(1L);
+        assertThat(meters.get(name(Rule.class, "abc", "cde", "1", "matched")).getCount()).isEqualTo(1L);
+
+        assertThat(meters.get(name(Rule.class, "abc", "not-matched")).getCount()).isEqualTo(0L);
+        assertThat(meters.get(name(Rule.class, "abc", "cde", "0", "not-matched")).getCount()).isEqualTo(0L);
+        assertThat(meters.get(name(Rule.class, "abc", "cde", "1", "not-matched")).getCount()).isEqualTo(0L);
+
+        assertThat(meters.get(name(Rule.class, "abc", "failed")).getCount()).isEqualTo(0L);
+        assertThat(meters.get(name(Rule.class, "abc", "cde", "0", "failed")).getCount()).isEqualTo(0L);
+        assertThat(meters.get(name(Rule.class, "abc", "cde", "1", "failed")).getCount()).isEqualTo(0L);
+
     }
 
     private PipelineRuleParser setupParser(Map<String, Function<?>> functions) {

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/StageIteratorTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/StageIteratorTest.java
@@ -24,13 +24,11 @@ import com.google.common.collect.Lists;
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
 import org.graylog.plugins.pipelineprocessor.ast.Stage;
 import org.jooq.lambda.Seq;
-import org.jooq.lambda.tuple.Tuple2;
 import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import static com.google.common.collect.ImmutableSortedSet.of;
 import static org.junit.Assert.assertArrayEquals;
@@ -62,11 +60,11 @@ public class StageIteratorTest {
                                         .build());
         final StageIterator iterator = new StageIterator(input);
         assertTrue(iterator.hasNext());
-        final Set<Tuple2<Stage, Pipeline>> nextStages = iterator.next();
+        final List<Stage> nextStages = iterator.next();
         assertEquals(1, nextStages.size());
 
-        final Tuple2<Stage, Pipeline> stage = Iterables.getOnlyElement(nextStages);
-        assertEquals(0, stage.v1.ruleReferences().size());
+        final Stage stage = Iterables.getOnlyElement(nextStages);
+        assertEquals(0, stage.ruleReferences().size());
     }
 
     @Test
@@ -87,13 +85,13 @@ public class StageIteratorTest {
                                         )).build());
         final StageIterator iterator = new StageIterator(input);
         //noinspection unchecked
-        final Set<Tuple2<Stage, Pipeline>>[] stages = Iterators.toArray(iterator, Set.class);
+        final List<Stage>[] stages = Iterators.toArray(iterator, List.class);
 
         assertEquals(2, stages.length);
         assertEquals(1, stages[0].size());
-        assertEquals("last set of stages are on stage 0", 0, Iterables.getOnlyElement(stages[0]).v1.stage());
+        assertEquals("last set of stages are on stage 0", 0, Iterables.getOnlyElement(stages[0]).stage());
         assertEquals(1, stages[1].size());
-        assertEquals("last set of stages are on stage 1", 10, Iterables.getOnlyElement(stages[1]).v1.stage());
+        assertEquals("last set of stages are on stage 1", 10, Iterables.getOnlyElement(stages[1]).stage());
     }
 
 
@@ -142,23 +140,23 @@ public class StageIteratorTest {
                                 Pipeline.builder()
                                         .name("p2")
                                         .stages(stages2).build()
-                                ,Pipeline.builder()
+                        ,Pipeline.builder()
                                         .name("p3")
                                         .stages(stages3).build()
                 );
         final StageIterator iterator = new StageIterator(input);
 
-        final List<Set<Tuple2<Stage, Pipeline>>> stageSets = Lists.newArrayList(iterator);
+        final List<List<Stage>> stageSets = Lists.newArrayList(iterator);
 
         assertEquals("5 different stages to execute", 5, stageSets.size());
 
-        for (Set<Tuple2<Stage, Pipeline>> stageSet : stageSets) {
+        for (List<Stage> stageSet : stageSets) {
             assertEquals("Each stage set should only contain stages with the same number",
                          1,
-                         Seq.seq(stageSet).map(Tuple2::v1).groupBy(Stage::stage).keySet().size());
+                         Seq.seq(stageSet).groupBy(Stage::stage).keySet().size());
         }
         assertArrayEquals("Stages must be sorted numerically",
                           new int[] {-1, 0, 4, 10, 11},
-                          stageSets.stream().flatMap(Collection::stream).map(Tuple2::v1).mapToInt(Stage::stage).distinct().toArray());
+                          stageSets.stream().flatMap(Collection::stream).mapToInt(Stage::stage).distinct().toArray());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <prerequisites>
         <maven>3.1.0</maven>
@@ -77,7 +78,6 @@
             </snapshots>
         </repository>
     </repositories>
-
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,26 @@
             <modules>
                 <module>benchmarks</module>
             </modules>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>pl.project13.maven</groupId>
+                        <artifactId>git-commit-id-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>get-the-git-infos</id>
+                                <goals>
+                                    <goal>revision</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <injectAllReactorProjects>false</injectAllReactorProjects>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This changeset is composed of the following parts:

* Commits up to 608c158 are identical to master and contain only preparation for the benchmark harness and an update to auto-value to be able to use the memoize feature
* The remaining commits, except 91615db, contain individual performance improvements to the interpreter and related code.
* Each of the commits 608c158, 	a493969, bf2a385, 754b348, 70777c0, 98279d6 have been run on a benchmark machine (Intel(R) Xeon(R) CPU E3-1246 v3 @ 3.50GHz, 32GB RAM, unloaded) using the benchmark script contained in the PR with 512m heap, a single fork, 10 iterations

The abbreviated benchmark output is:
```
==> pipeline-benchmarks-2.2.0-alpha.3-9-g608c158-2.2.0-alpha.3-9-g608c158.txt <==
  CI (99.9%): [1385436.481, 1412790.315] (assumes normal distribution)


# Run complete. Total time: 00:15:09

Benchmark                                         (directoryName)   Mode  Cnt        Score       Error  Units
PipelinePerformanceBenchmarks.runPipeline  complex_when_no_action  thrpt   10   451334.808 ±  1665.019  ops/s
PipelinePerformanceBenchmarks.runPipeline   many_stages_match_all  thrpt   10    29630.415 ±   120.101  ops/s
PipelinePerformanceBenchmarks.runPipeline          match_all_rule  thrpt   10   395247.279 ±  1434.916  ops/s
PipelinePerformanceBenchmarks.runPipeline             no_mappings  thrpt   10  1399113.398 ± 13676.917  ops/s

==> pipeline-benchmarks-2.2.0-alpha.3-10-ga493969-2.2.0-alpha.3-10-ga493969.txt <==
  CI (99.9%): [2070931.063, 2079740.125] (assumes normal distribution)


# Run complete. Total time: 00:15:09

Benchmark                                         (directoryName)   Mode  Cnt        Score      Error  Units
PipelinePerformanceBenchmarks.runPipeline  complex_when_no_action  thrpt   10   564402.245 ± 1278.518  ops/s
PipelinePerformanceBenchmarks.runPipeline   many_stages_match_all  thrpt   10    30481.007 ±  104.545  ops/s
PipelinePerformanceBenchmarks.runPipeline          match_all_rule  thrpt   10   476856.457 ± 1561.517  ops/s
PipelinePerformanceBenchmarks.runPipeline             no_mappings  thrpt   10  2075335.594 ± 4404.531  ops/s

==> pipeline-benchmarks-2.2.0-alpha.3-11-gbf2a385-2.2.0-alpha.3-11-gbf2a385.txt <==
  CI (99.9%): [2058532.378, 2110570.938] (assumes normal distribution)


# Run complete. Total time: 00:15:09

Benchmark                                         (directoryName)   Mode  Cnt        Score       Error  Units
PipelinePerformanceBenchmarks.runPipeline  complex_when_no_action  thrpt   10   598843.573 ±  2007.737  ops/s
PipelinePerformanceBenchmarks.runPipeline   many_stages_match_all  thrpt   10    36970.321 ±   140.487  ops/s
PipelinePerformanceBenchmarks.runPipeline          match_all_rule  thrpt   10   492778.060 ±  1854.453  ops/s
PipelinePerformanceBenchmarks.runPipeline             no_mappings  thrpt   10  2084551.658 ± 26019.280  ops/s

==> pipeline-benchmarks-2.2.0-alpha.3-12-g754b348-2.2.0-alpha.3-12-g754b348.txt <==
  CI (99.9%): [2108989.318, 2124128.145] (assumes normal distribution)


# Run complete. Total time: 00:15:09

Benchmark                                         (directoryName)   Mode  Cnt        Score      Error  Units
PipelinePerformanceBenchmarks.runPipeline  complex_when_no_action  thrpt   10   938895.302 ± 3515.188  ops/s
PipelinePerformanceBenchmarks.runPipeline   many_stages_match_all  thrpt   10    72202.619 ±  233.935  ops/s
PipelinePerformanceBenchmarks.runPipeline          match_all_rule  thrpt   10   827466.304 ± 3482.762  ops/s
PipelinePerformanceBenchmarks.runPipeline             no_mappings  thrpt   10  2116558.731 ± 7569.414  ops/s

==> pipeline-benchmarks-2.2.0-alpha.3-13-g70777c0-2.2.0-alpha.3-13-g70777c0.txt <==
  CI (99.9%): [4199000.430, 4274307.745] (assumes normal distribution)


# Run complete. Total time: 00:15:09

Benchmark                                         (directoryName)   Mode  Cnt        Score       Error  Units
PipelinePerformanceBenchmarks.runPipeline  complex_when_no_action  thrpt   10  1512659.715 ±  7809.532  ops/s
PipelinePerformanceBenchmarks.runPipeline   many_stages_match_all  thrpt   10   119700.179 ±   344.398  ops/s
PipelinePerformanceBenchmarks.runPipeline          match_all_rule  thrpt   10  1298122.127 ±  3159.002  ops/s
PipelinePerformanceBenchmarks.runPipeline             no_mappings  thrpt   10  4236654.088 ± 37653.657  ops/s

==> pipeline-benchmarks-2.2.0-alpha.3-15-g98279d6-2.2.0-alpha.3-15-g98279d6.txt <==

# Run complete. Total time: 00:15:09

Benchmark                                         (directoryName)   Mode  Cnt        Score       Error  Units
PipelinePerformanceBenchmarks.runPipeline  complex_when_no_action  thrpt   10  1805237.252 ±  6149.849  ops/s
PipelinePerformanceBenchmarks.runPipeline   many_stages_match_all  thrpt   10   120851.290 ±   484.560  ops/s
PipelinePerformanceBenchmarks.runPipeline          match_all_rule  thrpt   10  1417710.352 ±  2415.579  ops/s
PipelinePerformanceBenchmarks.runPipeline             no_mappings  thrpt   10  4176658.008 ± 24612.404  ops/s

```

A interactive plotly link is available at https://plot.ly/~kroepke/15/interpreter-performance/

![Screenshot of the plot](https://cloud.githubusercontent.com/assets/52014/19531884/9809af92-9639-11e6-8e4e-2cc8dc1780c0.png)

connected to #114