### PR TITLE
Messagelist benchmark

### DIFF
--- a/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/PipelinePerformanceBenchmarks.java
+++ b/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/PipelinePerformanceBenchmarks.java
@@ -16,18 +16,24 @@
  */
 package org.graylog.benchmarks.pipeline;
 
+import au.com.bytecode.opencsv.CSVParser;
 import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.MetricRegistry;
+import com.eaio.uuid.UUID;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
+import com.google.common.io.LineProcessor;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.moandjiezana.toml.Toml;
+import com.yourkit.api.Controller;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -66,6 +72,8 @@ import org.graylog2.shared.journal.NoopJournal;
 import org.graylog2.streams.StreamImpl;
 import org.graylog2.streams.StreamService;
 import org.joda.time.DateTime;
+import org.jooq.lambda.Seq;
+import org.jooq.lambda.tuple.Tuple2;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
@@ -73,6 +81,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
@@ -83,6 +92,7 @@ import org.openjdk.jmh.runner.options.TimeValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -91,8 +101,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -116,6 +128,7 @@ public class PipelinePerformanceBenchmarks {
         private PipelineInterpreter interpreter;
         private BenchmarkConfig config;
         private Injector injector;
+        private Iterator<Message> messageCycler;
         // enable when using yourkit for single runs
 //        private Controller controller;
 
@@ -159,6 +172,8 @@ public class PipelinePerformanceBenchmarks {
                             configFiles.put(Type.PIPELINE, inputFile);
                         } else if (name.equals("benchmark.toml")) {
                             configFiles.put(Type.CONFIG, inputFile);
+                        } else if (name.endsWith(".csv")) {
+                            configFiles.put(Type.MESSAGES, inputFile);
                         } else {
                             LOG.warn("unrecognized file {} found, it will be ignored.", inputFile);
                         }
@@ -230,6 +245,25 @@ public class PipelinePerformanceBenchmarks {
                                                                                .map(PipelineDao::id)
                                                                                .collect(Collectors.toSet())));
                 }
+            }
+
+            configFiles.get(Type.MESSAGES).forEach(file -> {
+                try {
+                    final List<Message> messages = com.google.common.io.Files.readLines(file,
+                                                                                        StandardCharsets.UTF_8,
+                                                                                        new CsvMessageFileProcessor());
+                    messageCycler = Iterators.cycle(messages);
+                    LOG.warn("read messages");
+                } catch (IOException e) {
+                    System.err.println(e.getMessage());
+                    System.exit(-3);
+                }
+            });
+            if (!configFiles.containsKey(Type.MESSAGES)) {
+                final ArrayList<Message> objects = Lists.newArrayList();
+                Seq.range(0, 25000).forEach(i -> objects.add(new Message("hallo welt", "127.0.0.1", Tools.nowUTC())));
+                messageCycler = Iterators.cycle(objects);
+                LOG.warn("created messages");
             }
 
             interpreter = injector.getInstance(PipelineInterpreter.class);
@@ -426,6 +460,39 @@ public class PipelinePerformanceBenchmarks {
             }
         }
 
+        private static class CsvMessageFileProcessor implements LineProcessor<List<Message>> {
+            String[] fieldNames;
+            private CSVParser csvParser = new CSVParser();
+            private List<Message> messages = Lists.newArrayList();
+            boolean firstLine = true;
+
+            @Override
+            public boolean processLine(@Nonnull String line) throws IOException {
+                final String[] strings = csvParser.parseLine(line);
+                if (strings == null) {
+                    return false;
+                }
+                if (firstLine) {
+                    fieldNames = strings;
+                    firstLine = false;
+                    return true;
+                }
+
+                final Map<String, Object> fields = Seq.of(fieldNames)
+                        .zipWithIndex()
+                        .map(nameAndIndex -> nameAndIndex.map2(index -> strings[Math.toIntExact(index)]))
+                        .collect(Collectors.toMap(Tuple2::v1, Tuple2::v2));
+                fields.put(Message.FIELD_ID, new UUID().toString());
+                messages.add(new Message(fields));
+                return true;
+            }
+
+            @Override
+            public List<Message> getResult() {
+                return messages;
+            }
+        }
+
         @SuppressWarnings({"unused", "MismatchedQueryAndUpdateOfCollection"})
         private class BenchmarkConfig {
             private String name;
@@ -445,13 +512,15 @@ public class PipelinePerformanceBenchmarks {
         private enum Type {
             CONFIG,
             RULE,
+            MESSAGES,
             PIPELINE
         }
     }
 
     @Benchmark
     public void runPipeline(PipelineConfig config, Blackhole bh) {
-        bh.consume(config.interpreter.process(MESSAGE));
+        // forever loop over the messages
+        bh.consume(config.interpreter.process(config.messageCycler.next()));
     }
 
     public static void main(String[] args) throws RunnerException, URISyntaxException, IOException {
@@ -465,7 +534,7 @@ public class PipelinePerformanceBenchmarks {
                                   .desc("Benchmark directory (default: 'benchmarks')")
                                   .required(false)
                                   .build());
-        options.addOption(new Option("f", "Number of forks (default 1). Set to 0 to allow attaching a debugger/profiler"));
+        options.addOption("f", true, "Number of forks (default 1). Set to 0 to allow attaching a debugger/profiler");
         options.addOption(Option.builder("n")
                                   .longOpt("name")
                                   .desc("Only run benchmark with the given name")
@@ -526,6 +595,7 @@ public class PipelinePerformanceBenchmarks {
                 .param("directoryName", benchmarkParams)
                 .jvmArgsAppend("-DbenchmarkDir="+benchmarkDir)
                 .resultFormat(ResultFormatType.CSV)
+                .addProfiler(GCProfiler.class)
                 .build();
 
         final Runner runner = new Runner(opt);


### PR DESCRIPTION
Add the ability to load lists of messages for a more realistic benchmark environment.

Tests without actual function calls and parsing are meaningless otherwise.