### PR TITLE
extract pipeline state updater from interpreter

### DIFF
--- a/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/FilterchainVsPipeline.java
+++ b/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/FilterchainVsPipeline.java
@@ -24,18 +24,19 @@ import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
-import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineStreamConnectionsService;
-import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbRuleService;
-import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineService;
 import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
 import org.graylog.plugins.pipelineprocessor.db.PipelineService;
 import org.graylog.plugins.pipelineprocessor.db.PipelineStreamConnectionsService;
 import org.graylog.plugins.pipelineprocessor.db.RuleDao;
 import org.graylog.plugins.pipelineprocessor.db.RuleService;
+import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineService;
+import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineStreamConnectionsService;
+import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbRuleService;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog.plugins.pipelineprocessor.parser.PipelineRuleParser;
+import org.graylog.plugins.pipelineprocessor.processors.ConfigurationStateUpdater;
 import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
 import org.graylog2.Configuration;
@@ -134,16 +135,19 @@ public class FilterchainVsPipeline {
 
             final PipelineRuleParser parser = setupParser(functions);
 
+            final ConfigurationStateUpdater stateUpdater = new ConfigurationStateUpdater(ruleService,
+                                                                                         pipelineService,
+                                                                                         pipelineStreamConnectionsService,
+                                                                                         parser,
+                                                                                         new MetricRegistry(),
+                                                                                         Executors.newScheduledThreadPool(1),
+                                                                                         mock(EventBus.class));
             final MetricRegistry metricRegistry = new MetricRegistry();
             interpreter = new PipelineInterpreter(
-                    ruleService,
-                    pipelineService,
-                    pipelineStreamConnectionsService,
-                    parser,
                     mock(Journal.class),
                     metricRegistry,
-                    Executors.newScheduledThreadPool(1),
-                    mock(EventBus.class)
+                    mock(EventBus.class),
+                    stateUpdater
             );
         }
 

--- a/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/PipelinePerformanceBenchmarks.java
+++ b/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/PipelinePerformanceBenchmarks.java
@@ -81,6 +81,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.profile.Profiler;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
@@ -1,0 +1,189 @@
+package org.graylog.plugins.pipelineprocessor.processors;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
+import org.graylog.plugins.pipelineprocessor.ast.Rule;
+import org.graylog.plugins.pipelineprocessor.db.PipelineService;
+import org.graylog.plugins.pipelineprocessor.db.PipelineStreamConnectionsService;
+import org.graylog.plugins.pipelineprocessor.db.RuleService;
+import org.graylog.plugins.pipelineprocessor.events.PipelineConnectionsChangedEvent;
+import org.graylog.plugins.pipelineprocessor.events.PipelinesChangedEvent;
+import org.graylog.plugins.pipelineprocessor.events.RulesChangedEvent;
+import org.graylog.plugins.pipelineprocessor.parser.ParseException;
+import org.graylog.plugins.pipelineprocessor.parser.PipelineRuleParser;
+import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+@Singleton
+public class ConfigurationStateUpdater {
+    private static final Logger log = LoggerFactory.getLogger(ConfigurationStateUpdater.class);
+
+    private final RuleService ruleService;
+    private final PipelineService pipelineService;
+    private final PipelineStreamConnectionsService pipelineStreamConnectionsService;
+    private final PipelineRuleParser pipelineRuleParser;
+    private final MetricRegistry metricRegistry;
+    private final ScheduledExecutorService scheduler;
+    private final EventBus serverEventBus;
+    /**
+     * non-null if the update has successfully loaded a state
+     */
+    private PipelineInterpreter.State latestState;
+
+    @Inject
+    public ConfigurationStateUpdater(RuleService ruleService,
+                                     PipelineService pipelineService,
+                                     PipelineStreamConnectionsService pipelineStreamConnectionsService,
+                                     PipelineRuleParser pipelineRuleParser,
+                                     MetricRegistry metricRegistry,
+                                     @Named("daemonScheduler") ScheduledExecutorService scheduler,
+                                     EventBus serverEventBus) {
+        this.ruleService = ruleService;
+        this.pipelineService = pipelineService;
+        this.pipelineStreamConnectionsService = pipelineStreamConnectionsService;
+        this.pipelineRuleParser = pipelineRuleParser;
+        this.metricRegistry = metricRegistry;
+        this.scheduler = scheduler;
+        this.serverEventBus = serverEventBus;
+
+        // listens to cluster wide Rule, Pipeline and pipeline stream connection changes
+        serverEventBus.register(this);
+
+        // eagerly propagate initial state
+        serverEventBus.post(reloadAndSave());
+    }
+
+    // only the singleton instance should mutate itself, others are welcome to reload a new state, but we don't
+    // currently allow direct global state updates from external sources (if you need to, send an event on the bus instead)
+    private synchronized PipelineInterpreter.State reloadAndSave() {
+        latestState = reload();
+        return latestState;
+    }
+
+    // this should not run in parallel to avoid useless database traffic
+    public synchronized PipelineInterpreter.State reload() {
+        // read all rules and parse them
+        Map<String, Rule> ruleNameMap = Maps.newHashMap();
+        ruleService.loadAll().forEach(ruleDao -> {
+            Rule rule;
+            try {
+                rule = pipelineRuleParser.parseRule(ruleDao.id(), ruleDao.source(), false);
+            } catch (ParseException e) {
+                rule = Rule.alwaysFalse("Failed to parse rule: " + ruleDao.id());
+            }
+            ruleNameMap.put(rule.name(), rule);
+        });
+
+        // read all pipelines and parse them
+        ImmutableMap.Builder<String, Pipeline> pipelineIdMap = ImmutableMap.builder();
+        pipelineService.loadAll().forEach(pipelineDao -> {
+            Pipeline pipeline;
+            try {
+                pipeline = pipelineRuleParser.parsePipeline(pipelineDao.id(), pipelineDao.source());
+            } catch (ParseException e) {
+                pipeline = Pipeline.empty("Failed to parse pipeline" + pipelineDao.id());
+            }
+            //noinspection ConstantConditions
+            pipelineIdMap.put(pipelineDao.id(), resolvePipeline(pipeline, ruleNameMap));
+        });
+
+        final ImmutableMap<String, Pipeline> currentPipelines = pipelineIdMap.build();
+
+        // read all stream connections of those pipelines to allow processing messages through them
+        final HashMultimap<String, Pipeline> connections = HashMultimap.create();
+        for (PipelineConnections streamConnection : pipelineStreamConnectionsService.loadAll()) {
+            streamConnection.pipelineIds().stream()
+                    .map(currentPipelines::get)
+                    .filter(Objects::nonNull)
+                    .forEach(pipeline -> connections.put(streamConnection.streamId(), pipeline));
+        }
+        ImmutableSetMultimap<String, Pipeline> streamPipelineConnections = ImmutableSetMultimap.copyOf(connections);
+
+        return new PipelineInterpreter.State(currentPipelines, streamPipelineConnections);
+    }
+
+    /**
+     * Can be used to inspect or use the current state of the pipeline system.
+     * For example, the interpreter
+     * @return the currently loaded state of the updater
+     */
+    public PipelineInterpreter.State getLatestState() {
+        return latestState;
+    }
+
+    @Nonnull
+    private Pipeline resolvePipeline(Pipeline pipeline, Map<String, Rule> ruleNameMap) {
+        log.debug("Resolving pipeline {}", pipeline.name());
+
+        pipeline.stages().forEach(stage -> {
+            final List<Rule> resolvedRules = stage.ruleReferences().stream()
+                    .map(ref -> {
+                        Rule rule = ruleNameMap.get(ref);
+                        if (rule == null) {
+                            rule = Rule.alwaysFalse("Unresolved rule " + ref);
+                        }
+                        // make a copy so that the metrics match up (we don't share actual objects between stages)
+                        rule = rule.toBuilder().build();
+                        log.debug("Resolved rule `{}` to {}", ref, rule);
+                        // include back reference to stage
+                        rule.registerMetrics(metricRegistry, pipeline.id(), String.valueOf(stage.stage()));
+                        return rule;
+                    })
+                    .collect(Collectors.toList());
+            stage.setRules(resolvedRules);
+            stage.setPipeline(pipeline);
+            stage.registerMetrics(metricRegistry, pipeline.id());
+        });
+
+        pipeline.registerMetrics(metricRegistry);
+        return pipeline;
+    }
+
+    // TODO avoid reloading everything on every change, certain changes can get away with doing less work
+    @Subscribe
+    public void handleRuleChanges(RulesChangedEvent event) {
+        event.deletedRuleIds().forEach(id -> {
+            log.debug("Invalidated rule {}", id);
+            metricRegistry.removeMatching((name, metric) -> name.startsWith(name(Rule.class, id)));
+        });
+        event.updatedRuleIds().forEach(id -> log.debug("Refreshing rule {}", id));
+        scheduler.schedule(() -> serverEventBus.post(reloadAndSave()), 0, TimeUnit.SECONDS);
+    }
+
+    @Subscribe
+    public void handlePipelineChanges(PipelinesChangedEvent event) {
+        event.deletedPipelineIds().forEach(id -> {
+            log.debug("Invalidated pipeline {}", id);
+            metricRegistry.removeMatching((name, metric) -> name.startsWith(name(Pipeline.class, id)));
+        });
+        event.updatedPipelineIds().forEach(id -> log.debug("Refreshing pipeline {}", id));
+        scheduler.schedule(() -> serverEventBus.post(reloadAndSave()), 0, TimeUnit.SECONDS);
+    }
+
+    @Subscribe
+    public void handlePipelineConnectionChanges(PipelineConnectionsChangedEvent event) {
+        log.debug("Pipeline stream connection changed: {}", event);
+        scheduler.schedule(() -> serverEventBus.post(reloadAndSave()), 0, TimeUnit.SECONDS);
+    }
+
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.elasticsearch.common.Strings;
+import org.graylog.plugins.pipelineprocessor.processors.ConfigurationStateUpdater;
 import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
 import org.graylog.plugins.pipelineprocessor.simulator.PipelineInterpreterTracer;
 import org.graylog2.audit.jersey.NoAuditEvent;
@@ -50,13 +51,16 @@ import java.util.List;
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication
 public class SimulatorResource extends RestResource implements PluginRestResource {
+    private final ConfigurationStateUpdater pipelineStateUpdater;
     private final StreamService streamService;
     private final PipelineInterpreter pipelineInterpreter;
 
     @Inject
     public SimulatorResource(PipelineInterpreter pipelineInterpreter,
+                             ConfigurationStateUpdater pipelineStateUpdater,
                              StreamService streamService) {
         this.pipelineInterpreter = pipelineInterpreter;
+        this.pipelineStateUpdater = pipelineStateUpdater;
         this.streamService = streamService;
     }
 
@@ -80,7 +84,8 @@ public class SimulatorResource extends RestResource implements PluginRestResourc
         final PipelineInterpreterTracer pipelineInterpreterTracer = new PipelineInterpreterTracer();
 
         org.graylog2.plugin.Messages processedMessages = pipelineInterpreter.process(message,
-                                                                                     pipelineInterpreterTracer.getSimulatorInterpreterListener());
+                                                                                     pipelineInterpreterTracer.getSimulatorInterpreterListener(),
+                                                                                     pipelineStateUpdater.getLatestState());
         for (Message processedMessage : processedMessages) {
             simulationResults.add(ResultMessageSummary.create(null, processedMessage.getFields(), ""));
         }

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -102,15 +102,18 @@ public class PipelineInterpreterTest {
 
         final PipelineRuleParser parser = setupParser(functions);
 
+        final ConfigurationStateUpdater stateUpdater = new ConfigurationStateUpdater(ruleService,
+                                                                                     pipelineService,
+                                                                                     pipelineStreamConnectionsService,
+                                                                                     parser,
+                                                                                     new MetricRegistry(),
+                                                                                     Executors.newScheduledThreadPool(1),
+                                                                                     mock(EventBus.class));
         final PipelineInterpreter interpreter = new PipelineInterpreter(
-                ruleService,
-                pipelineService,
-                pipelineStreamConnectionsService,
-                parser,
                 mock(Journal.class),
                 new MetricRegistry(),
-                Executors.newScheduledThreadPool(1),
-                mock(EventBus.class)
+                mock(EventBus.class),
+                stateUpdater
         );
 
         Message msg = new Message("original message", "test", Tools.nowUTC());
@@ -156,15 +159,18 @@ public class PipelineInterpreterTest {
         final PipelineRuleParser parser = setupParser(functions);
 
         final MetricRegistry metricRegistry = new MetricRegistry();
+        final ConfigurationStateUpdater stateUpdater = new ConfigurationStateUpdater(ruleService,
+                                                                                     pipelineService,
+                                                                                     pipelineStreamConnectionsService,
+                                                                                     parser,
+                                                                                     metricRegistry,
+                                                                                     Executors.newScheduledThreadPool(1),
+                                                                                     mock(EventBus.class));
         final PipelineInterpreter interpreter = new PipelineInterpreter(
-                ruleService,
-                pipelineService,
-                pipelineStreamConnectionsService,
-                parser,
                 mock(Journal.class),
                 metricRegistry,
-                Executors.newScheduledThreadPool(1),
-                mock(EventBus.class)
+                mock(EventBus.class),
+                stateUpdater
         );
 
         interpreter.process(new Message("", "", Tools.nowUTC()));


### PR DESCRIPTION
by separating the state computation and updating from the interpreter we can control what state we want to use for interpretation
this allows a cleaner simulation without interfering with current processing

it also makes the code a little easier to follow by separating the two different concerns