### PR TITLE
Use explicit default stream

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.pipelineprocessor;
 
 import org.graylog.plugins.pipelineprocessor.audit.PipelineProcessorAuditEventTypes;
 import org.graylog.plugins.pipelineprocessor.functions.ProcessorFunctionsModule;
+import org.graylog.plugins.pipelineprocessor.periodical.LegacyDefaultStreamMigration;
 import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineConnectionsResource;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineResource;
@@ -39,6 +40,8 @@ public class PipelineProcessorModule extends PluginModule {
 
     @Override
     protected void configure() {
+        addPeriodical(LegacyDefaultStreamMigration.class);
+
         addMessageProcessor(PipelineInterpreter.class, PipelineInterpreter.Descriptor.class);
         addRestResource(RuleResource.class);
         addRestResource(PipelineResource.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/db/PipelineStreamConnectionsService.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/db/PipelineStreamConnectionsService.java
@@ -27,4 +27,6 @@ public interface PipelineStreamConnectionsService {
     PipelineConnections load(String streamId) throws NotFoundException;
 
     Set<PipelineConnections> loadAll();
+
+    void delete(String streamId);
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/db/memory/InMemoryPipelineStreamConnectionsService.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/db/memory/InMemoryPipelineStreamConnectionsService.java
@@ -41,6 +41,16 @@ public class InMemoryPipelineStreamConnectionsService implements PipelineStreamC
         return ImmutableSet.copyOf(store.values());
     }
 
+    @Override
+    public void delete(String streamId) {
+        try {
+            final PipelineConnections connections = load(streamId);
+            store.remove(connections.id());
+        } catch (NotFoundException e) {
+            // Do nothing
+        }
+    }
+
     private String createId() {
         return String.valueOf(idGen.incrementAndGet());
     }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineStreamConnectionsService.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineStreamConnectionsService.java
@@ -86,4 +86,14 @@ public class MongoDbPipelineStreamConnectionsService implements PipelineStreamCo
             return Collections.emptySet();
         }
     }
+
+    @Override
+    public void delete(String streamId) {
+        try {
+            final PipelineConnections connections = load(streamId);
+            dbCollection.removeById(connections.id());
+        } catch (NotFoundException e) {
+            log.debug("No connections found for stream " + streamId);
+        }
+    }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/events/LegacyDefaultStreamMigrated.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/events/LegacyDefaultStreamMigrated.java
@@ -1,0 +1,18 @@
+package org.graylog.plugins.pipelineprocessor.events;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class LegacyDefaultStreamMigrated {
+    @JsonProperty
+    public abstract boolean migrationDone();
+
+    @JsonCreator
+    public static LegacyDefaultStreamMigrated create(@JsonProperty("migration_done") boolean migrationDone) {
+        return new AutoValue_LegacyDefaultStreamMigrated(migrationDone);
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/periodical/LegacyDefaultStreamMigration.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/periodical/LegacyDefaultStreamMigration.java
@@ -1,0 +1,83 @@
+package org.graylog.plugins.pipelineprocessor.periodical;
+
+import org.graylog.plugins.pipelineprocessor.db.PipelineStreamConnectionsService;
+import org.graylog.plugins.pipelineprocessor.events.LegacyDefaultStreamMigrated;
+import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
+import org.graylog2.database.NotFoundException;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.periodical.Periodical;
+import org.graylog2.plugin.streams.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+public class LegacyDefaultStreamMigration extends Periodical {
+    private static final Logger LOG = LoggerFactory.getLogger(LegacyDefaultStreamMigration.class);
+    private final ClusterConfigService clusterConfigService;
+    private final PipelineStreamConnectionsService connectionsService;
+
+    private static final String LEGACY_STREAM_ID = "default";
+
+    @Inject
+    public LegacyDefaultStreamMigration(ClusterConfigService clusterConfigService, PipelineStreamConnectionsService connectionsService) {
+        this.clusterConfigService = clusterConfigService;
+        this.connectionsService = connectionsService;
+    }
+
+    @Override
+    public boolean runsForever() {
+        return true;
+    }
+
+    @Override
+    public boolean stopOnGracefulShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean masterOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean startOnThisNode() {
+        final LegacyDefaultStreamMigrated migrationState =
+                clusterConfigService.getOrDefault(LegacyDefaultStreamMigrated.class,
+                        LegacyDefaultStreamMigrated.create(false));
+        return !migrationState.migrationDone();
+    }
+
+    @Override
+    public boolean isDaemon() {
+        return false;
+    }
+
+    @Override
+    public int getInitialDelaySeconds() {
+        return 0;
+    }
+
+    @Override
+    public int getPeriodSeconds() {
+        return 0;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOG;
+    }
+
+    @Override
+    public void doRun() {
+        try {
+            final PipelineConnections defaultConnections = connectionsService.load(LEGACY_STREAM_ID);
+            connectionsService.save(defaultConnections.toBuilder().streamId(Stream.DEFAULT_STREAM_ID).build());
+            connectionsService.delete(LEGACY_STREAM_ID);
+            clusterConfigService.write(LegacyDefaultStreamMigrated.create(true));
+            LOG.info("Pipeline connections to legacy default streams migrated successfully.");
+        } catch (NotFoundException e) {
+            LOG.info("Legacy default stream has no connections, no migration needed.");
+        }
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/listeners/InterpreterListener.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/listeners/InterpreterListener.java
@@ -26,7 +26,6 @@ import java.util.Set;
 public interface InterpreterListener {
     void startProcessing();
     void finishProcessing();
-    void processDefaultStream(Message message, Set<Pipeline> pipelines);
     void processStreams(Message message, Set<Pipeline> pipelines, Set<String> streams);
     void enterStage(Stage stage);
     void exitStage(Stage stage);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/listeners/NoopInterpreterListener.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/listeners/NoopInterpreterListener.java
@@ -35,11 +35,6 @@ public class NoopInterpreterListener implements InterpreterListener {
     }
 
     @Override
-    public void processDefaultStream(Message messageId, Set<Pipeline> pipelines) {
-
-    }
-
-    @Override
     public void processStreams(Message messageId, Set<Pipeline> pipelines, Set<String> streams) {
 
     }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
@@ -72,10 +72,9 @@ public class SimulatorResource extends RestResource implements PluginRestResourc
         checkPermission(RestPermissions.STREAMS_READ, request.streamId());
 
         final Message message = new Message(request.message());
-        if (!request.streamId().equals("default")) {
-            final Stream stream = streamService.load(request.streamId());
-            message.addStream(stream);
-        }
+        final Stream stream = streamService.load(request.streamId());
+        message.addStream(stream);
+
         if (!Strings.isNullOrEmpty(request.inputId())) {
             message.setSourceInputId(request.inputId());
         }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/simulator/SimulatorInterpreterListener.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/simulator/SimulatorInterpreterListener.java
@@ -42,11 +42,6 @@ class SimulatorInterpreterListener implements InterpreterListener {
     }
 
     @Override
-    public void processDefaultStream(Message message, Set<Pipeline> pipelines) {
-        executionTrace.addTrace("Message " + message.getId() + " running " + pipelines + " for default stream");
-    }
-
-    @Override
     public void processStreams(Message message, Set<Pipeline> pipelines, Set<String> streams) {
         executionTrace.addTrace("Message " + message.getId() + " running " + pipelines + " for streams " + streams);
     }

--- a/plugin/src/web/pipelines/PipelineDetailsPage.jsx
+++ b/plugin/src/web/pipelines/PipelineDetailsPage.jsx
@@ -47,11 +47,6 @@ const PipelineDetailsPage = React.createClass({
     PipelineConnectionsActions.list();
 
     StreamsStore.listStreams().then((streams) => {
-      streams.push({
-        id: 'default',
-        title: 'Default',
-        description: 'Stream used by default for messages not matching another stream.',
-      });
       this.setState({ streams });
     });
   },

--- a/plugin/src/web/pipelines/ProcessingTimelineComponent.jsx
+++ b/plugin/src/web/pipelines/ProcessingTimelineComponent.jsx
@@ -27,11 +27,6 @@ const ProcessingTimelineComponent = React.createClass({
     PipelineConnectionsActions.list();
 
     StreamsStore.listStreams().then((streams) => {
-      streams.push({
-        id: 'default',
-        title: 'Default',
-        description: 'Stream used by default for messages not matching another stream.',
-      });
       this.setState({ streams });
     });
   },

--- a/plugin/src/web/simulator/ProcessorSimulator.jsx
+++ b/plugin/src/web/simulator/ProcessorSimulator.jsx
@@ -13,15 +13,20 @@ import SimulatorActions from './SimulatorActions';
 // eslint-disable-next-line no-unused-vars
 import SimulatorStore from './SimulatorStore';
 
+const DEFAULT_STREAM_ID = '000000000000000000000001';
+
 const ProcessorSimulator = React.createClass({
   propTypes: {
     streams: React.PropTypes.array.isRequired,
   },
 
   getInitialState() {
+    // The default stream could not be present in a system. In that case we fallback to the first available stream.
+    this.defaultStream = this.props.streams.find(s => s.id === DEFAULT_STREAM_ID) || this.props.streams[0];
+
     return {
       message: undefined,
-      stream: this.props.streams.find(s => s.id.toLowerCase() === 'default'),
+      stream: this.defaultStream,
       simulation: undefined,
       loading: false,
       error: undefined,
@@ -79,7 +84,7 @@ const ProcessorSimulator = React.createClass({
 
     const streamHelp = (
       <span>
-        Select a stream to use during simulation, the <em>Default</em> stream is used by default.
+        Select a stream to use during simulation, the <em>{this.defaultStream.title}</em> stream is used by default.
       </span>
     );
 

--- a/plugin/src/web/simulator/ProcessorSimulator.jsx
+++ b/plugin/src/web/simulator/ProcessorSimulator.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import { Col, Input, Row } from 'react-bootstrap';
+import { Col, Input, Panel, Row } from 'react-bootstrap';
 import naturalSort from 'javascript-natural-sort';
+import { LinkContainer } from 'react-router-bootstrap';
 
 import { Select } from 'components/common';
 import RawMessageLoader from 'components/messageloaders/RawMessageLoader';
 import SimulationResults from './SimulationResults';
+
+import Routes from 'routing/Routes';
 
 import SimulatorActions from './SimulatorActions';
 // eslint-disable-next-line no-unused-vars
@@ -58,6 +61,22 @@ const ProcessorSimulator = React.createClass({
   },
 
   render() {
+    if (this.props.streams.length === 0) {
+      return (
+        <div>
+          <Row className="row-sm">
+            <Col md={8} mdOffset={2}>
+              <Panel bsStyle="danger" header="No streams found">
+                Pipelines operate on streams, but your system currently has no streams. Please{' '}
+                <LinkContainer to={Routes.STREAMS}><a>create a stream</a></LinkContainer>{' '}
+                and come back here later to test pipelines processing messages in your new stream.
+              </Panel>
+            </Col>
+          </Row>
+        </div>
+      );
+    }
+
     const streamHelp = (
       <span>
         Select a stream to use during simulation, the <em>Default</em> stream is used by default.

--- a/plugin/src/web/simulator/SimulatorPage.jsx
+++ b/plugin/src/web/simulator/SimulatorPage.jsx
@@ -21,11 +21,6 @@ const SimulatorPage = React.createClass({
 
   componentDidMount() {
     StreamsStore.listStreams().then((streams) => {
-      streams.push({
-        id: 'default',
-        title: 'Default',
-        description: 'Stream used by default for messages not matching another stream.',
-      });
       this.setState({ streams: streams });
     });
   },


### PR DESCRIPTION
These changes adapt the pipeline processor to use the explicit default stream. To facilitate the migration to people already using pipelines connected to the default stream, I included a migration periodical that will fix the connections in the database.
