### PR TITLE
Interpreter improvements/Rule code generation

### DIFF
--- a/benchmarks/benchmarks/complex_when_no_action/simple.pipeline
+++ b/benchmarks/benchmarks/complex_when_no_action/simple.pipeline
@@ -1,4 +1,4 @@
 pipeline "simple"
 stage 0 match all
-  rule "match everything"
+  rule "complex when"
 end

--- a/benchmarks/benchmarks/grok_extract/benchmark.toml
+++ b/benchmarks/benchmarks/grok_extract/benchmark.toml
@@ -1,0 +1,6 @@
+name = "Grok extraction benchmark"
+
+[[streams]]
+    name = "default"
+    description = "All incoming messages"
+    pipelines = ["grok"]

--- a/benchmarks/benchmarks/grok_extract/grok_job_extraction.rule
+++ b/benchmarks/benchmarks/grok_extract/grok_job_extraction.rule
@@ -1,0 +1,9 @@
+rule "grok jenkins extraction"
+when
+    to_string($message.source) == "jenkins.torch.sh" &&
+    regex("#\\d+", to_string($message.message)).matches == true && !has_field("something_that_doesnt_exist")
+then
+    let fields = grok("%{NOTSPACE:job_name}%{SPACE:unwanted}#%{NUMBER:job_number}\\sStarted by\\s%{USERNAME:user}", to_string($message.message), true);
+
+    set_fields(fields);
+end

--- a/benchmarks/benchmarks/grok_extract/simple.pipeline
+++ b/benchmarks/benchmarks/grok_extract/simple.pipeline
@@ -1,0 +1,4 @@
+pipeline "grok"
+stage 0 match all
+  rule "grok jenkins extraction"
+end

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -104,7 +104,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
         <jmh.version>1.14.1</jmh.version>
         <javac.target>1.8</javac.target>
         <uberjar.name>pipeline-benchmarks-${git.commit.id.describe}</uberjar.name>
-        <graylog.version>2.2.0-alpha.4-SNAPSHOT</graylog.version>
+        <graylog.version>2.2.0-alpha.5-SNAPSHOT</graylog.version>
     </properties>
 
     <build>

--- a/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/FilterchainVsPipeline.java
+++ b/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/FilterchainVsPipeline.java
@@ -16,14 +16,17 @@
  */
 package org.graylog.benchmarks.pipeline;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import com.codahale.metrics.MetricRegistry;
+
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
+import org.graylog.plugins.pipelineprocessor.codegen.CodeGenerator;
 import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
 import org.graylog.plugins.pipelineprocessor.db.PipelineService;
 import org.graylog.plugins.pipelineprocessor.db.PipelineStreamConnectionsService;
@@ -153,7 +156,7 @@ public class FilterchainVsPipeline {
 
         private PipelineRuleParser setupParser(Map<String, org.graylog.plugins.pipelineprocessor.ast.functions.Function<?>> functions) {
             final FunctionRegistry functionRegistry = new FunctionRegistry(functions);
-            return new PipelineRuleParser(functionRegistry);
+            return new PipelineRuleParser(functionRegistry, new CodeGenerator(functionRegistry));
         }
 
     }

--- a/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/FilterchainVsPipeline.java
+++ b/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/FilterchainVsPipeline.java
@@ -138,14 +138,15 @@ public class FilterchainVsPipeline {
 
             final PipelineRuleParser parser = setupParser(functions);
 
-            final ConfigurationStateUpdater stateUpdater = new ConfigurationStateUpdater(ruleService,
-                                                                                         pipelineService,
-                                                                                         pipelineStreamConnectionsService,
-                                                                                         parser,
-                                                                                         new MetricRegistry(),
-                                                                                         Executors.newScheduledThreadPool(1),
-                                                                                         mock(EventBus.class));
             final MetricRegistry metricRegistry = new MetricRegistry();
+            final ConfigurationStateUpdater stateUpdater = new ConfigurationStateUpdater(ruleService,
+                    pipelineService,
+                    pipelineStreamConnectionsService,
+                    parser,
+                    new MetricRegistry(),
+                    Executors.newScheduledThreadPool(1),
+                    mock(EventBus.class),
+                    (currentPipelines, streamPipelineConnections) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, metricRegistry, 1, true));
             interpreter = new PipelineInterpreter(
                     mock(Journal.class),
                     metricRegistry,

--- a/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/FilterchainVsPipeline.java
+++ b/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/FilterchainVsPipeline.java
@@ -136,7 +136,8 @@ public class FilterchainVsPipeline {
             functions.put(SetField.NAME, new SetField());
             functions.put(StringConversion.NAME, new StringConversion());
 
-            final PipelineRuleParser parser = setupParser(functions);
+            final FunctionRegistry functionRegistry = new FunctionRegistry(functions);
+            final PipelineRuleParser parser = new PipelineRuleParser(functionRegistry, new CodeGenerator());
 
             final MetricRegistry metricRegistry = new MetricRegistry();
             final ConfigurationStateUpdater stateUpdater = new ConfigurationStateUpdater(ruleService,
@@ -144,20 +145,17 @@ public class FilterchainVsPipeline {
                     pipelineStreamConnectionsService,
                     parser,
                     new MetricRegistry(),
+                    functionRegistry,
                     Executors.newScheduledThreadPool(1),
                     mock(EventBus.class),
-                    (currentPipelines, streamPipelineConnections) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, metricRegistry, 1, true));
+                    (currentPipelines, streamPipelineConnections, classLoader) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, null, metricRegistry, 1, true),
+                    false);
             interpreter = new PipelineInterpreter(
                     mock(Journal.class),
                     metricRegistry,
                     mock(EventBus.class),
                     stateUpdater
             );
-        }
-
-        private PipelineRuleParser setupParser(Map<String, org.graylog.plugins.pipelineprocessor.ast.functions.Function<?>> functions) {
-            final FunctionRegistry functionRegistry = new FunctionRegistry(functions);
-            return new PipelineRuleParser(functionRegistry, new CodeGenerator(functionRegistry));
         }
 
     }

--- a/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/PipelinePerformanceBenchmarks.java
+++ b/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/PipelinePerformanceBenchmarks.java
@@ -54,6 +54,7 @@ import org.graylog.plugins.pipelineprocessor.db.RuleService;
 import org.graylog.plugins.pipelineprocessor.db.memory.InMemoryServicesModule;
 import org.graylog.plugins.pipelineprocessor.functions.ProcessorFunctionsModule;
 import org.graylog.plugins.pipelineprocessor.parser.PipelineRuleParser;
+import org.graylog.plugins.pipelineprocessor.processors.ConfigurationStateUpdater;
 import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
 import org.graylog2.database.NotFoundException;
@@ -303,7 +304,7 @@ public class PipelinePerformanceBenchmarks {
             metricRegistry = metrics;
 
             // toggle code generation
-            PipelineRuleParser.setAllowCodeGeneration(Boolean.valueOf(codeGenerator));
+            ConfigurationStateUpdater.setAllowCodeGeneration(Boolean.valueOf(codeGenerator));
             interpreter = injector.getInstance(PipelineInterpreter.class);
         }
 

--- a/benchmarks/src/main/resources/META-INF/services/org.openjdk.jmh.profile.Profiler
+++ b/benchmarks/src/main/resources/META-INF/services/org.openjdk.jmh.profile.Profiler
@@ -1,0 +1,1 @@
+org.graylog.benchmarks.pipeline.PipelinePerformanceBenchmarks$MetricsProfiler

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -87,6 +87,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.squareup</groupId>
+                <artifactId>javapoet</artifactId>
+                <version>1.7.0</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
@@ -152,6 +158,11 @@
             <groupId>org.jooq</groupId>
             <artifactId>jool</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.squareup</groupId>
+            <artifactId>javapoet</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -91,6 +91,11 @@
                 <artifactId>javapoet</artifactId>
                 <version>1.7.0</version>
             </dependency>
+            <dependency>
+                <groupId>net.openhft</groupId>
+                <artifactId>compiler</artifactId>
+                <version>2.2.4</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -161,6 +166,10 @@
         <dependency>
             <groupId>com.squareup</groupId>
             <artifactId>javapoet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.openhft</groupId>
+            <artifactId>compiler</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/src/main/antlr4/org/graylog/plugins/pipelineprocessor/parser/RuleLang.g4
+++ b/plugin/src/main/antlr4/org/graylog/plugins/pipelineprocessor/parser/RuleLang.g4
@@ -77,13 +77,13 @@ ruleDeclaration
 expression
     :   '(' expression ')'                                              # ParenExpr
     |   literal                                                         # LiteralPrimary
+    |   functionCall                                                    # Func
     |   Identifier                                                      # Identifier
     |   '[' (expression (',' expression)*)* ']'                         # ArrayLiteralExpr
     |   '{' (propAssignment (',' propAssignment)*)* '}'                 # MapLiteralExpr
     |   MessageRef '.' field=expression                                 # MessageRef
     |   fieldSet=expression '.' field=expression                        # Nested
     |   array=expression '[' index=expression ']'                       # IndexedAccess
-    |   functionCall                                                    # Func
     |   sign=('+'|'-') expr=expression                                  # SignedExpression
     |   Not expression                                                  # Not
     |   left=expression mult=('*'|'/'|'%') right=expression             # Multiplication

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineConfig.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineConfig.java
@@ -1,0 +1,14 @@
+package org.graylog.plugins.pipelineprocessor;
+
+import com.github.joschi.jadconfig.Parameter;
+
+import org.graylog2.plugin.PluginConfigBean;
+
+public class PipelineConfig implements PluginConfigBean {
+
+    @Parameter("cached_stageiterators")
+    private boolean cachedStageIterators = true;
+
+    @Parameter("generate_native_code")
+    private boolean generateNativeCode = true;
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
@@ -37,7 +37,7 @@ public class PipelineProcessorModule extends PluginModule {
 
     @Override
     public Set<? extends PluginConfigBean> getConfigBeans() {
-        return Collections.emptySet();
+        return Collections.singleton(new PipelineConfig());
     }
 
     @Override
@@ -60,5 +60,7 @@ public class PipelineProcessorModule extends PluginModule {
         install(new FactoryModuleBuilder().build(PipelineInterpreter.State.Factory.class));
 
         addAuditEventTypes(PipelineProcessorAuditEventTypes.class);
+
+        addConfigBeans();
     }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
@@ -16,6 +16,8 @@
  */
 package org.graylog.plugins.pipelineprocessor;
 
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+
 import org.graylog.plugins.pipelineprocessor.audit.PipelineProcessorAuditEventTypes;
 import org.graylog.plugins.pipelineprocessor.functions.ProcessorFunctionsModule;
 import org.graylog.plugins.pipelineprocessor.periodical.LegacyDefaultStreamMigration;
@@ -54,6 +56,8 @@ public class PipelineProcessorModule extends PluginModule {
         installSearchResponseDecorator(searchResponseDecoratorBinder(),
                 PipelineProcessorMessageDecorator.class,
                 PipelineProcessorMessageDecorator.Factory.class);
+
+        install(new FactoryModuleBuilder().build(PipelineInterpreter.State.Factory.class));
 
         addAuditEventTypes(PipelineProcessorAuditEventTypes.class);
     }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/Rule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/Rule.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.pipelineprocessor.ast;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
 import com.codahale.metrics.Meter;
@@ -28,7 +29,13 @@ import org.graylog.plugins.pipelineprocessor.ast.expressions.BooleanExpression;
 import org.graylog.plugins.pipelineprocessor.ast.expressions.LogicalExpression;
 import org.graylog.plugins.pipelineprocessor.ast.statements.Statement;
 import org.graylog.plugins.pipelineprocessor.codegen.GeneratedRule;
+import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
+import org.reflections.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -37,6 +44,7 @@ import javax.annotation.Nullable;
 
 @AutoValue
 public abstract class Rule {
+    private static final Logger LOG = LoggerFactory.getLogger(Rule.class);
 
     private transient Set<String> metricNames = Sets.newHashSet();
 
@@ -59,6 +67,9 @@ public abstract class Rule {
     public abstract Collection<Statement> then();
 
     @Nullable
+    public abstract Class<? extends GeneratedRule> generatedRuleClass();
+
+    @Nullable
     public abstract GeneratedRule generatedRule();
 
     public static Builder builder() {
@@ -69,11 +80,6 @@ public abstract class Rule {
 
     public Rule withId(String id) {
         return toBuilder().id(id).build();
-    }
-
-    public Rule withGeneratedRule(GeneratedRule generated) {
-        // TODO this instance should not be shared across rule instances (but currently is)!
-        return toBuilder().generatedRule(generated).build();
     }
 
     public static Rule alwaysFalse(String name) {
@@ -161,6 +167,33 @@ public abstract class Rule {
         }
     }
 
+    /**
+     * Creates a copy of this Rule with a new instance of the generated rule class if present.
+     *
+     * This prevents sharing instances across threads, which is not supported for performance reasons.
+     * Otherwise the generated code would need to be thread safe, adding to the runtime overhead.
+     * Instead we buy speed by spending more memory.
+     *
+     * @param functionRegistry the registered functions of the system
+     * @return a copy of this rule with a new instance of its generated code
+     */
+    public Rule invokableCopy(FunctionRegistry functionRegistry) {
+        final Builder builder = toBuilder();
+        final Class<? extends GeneratedRule> ruleClass = generatedRuleClass();
+        if (ruleClass != null) {
+            try {
+                //noinspection unchecked
+                final Set<Constructor> constructors = ReflectionUtils.getConstructors(ruleClass);
+                final Constructor onlyElement = Iterables.getOnlyElement(constructors);
+                final GeneratedRule instance = (GeneratedRule) onlyElement.newInstance(functionRegistry);
+                builder.generatedRule(instance);
+            } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+                LOG.warn("Unable to generate code for rule {}: {}", id(), e);
+            }
+        }
+        return builder.build();
+    }
+
     @AutoValue.Builder
     public abstract static class Builder {
 
@@ -168,7 +201,8 @@ public abstract class Rule {
         public abstract Builder name(String name);
         public abstract Builder when(LogicalExpression condition);
         public abstract Builder then(Collection<Statement> actions);
-        public abstract Builder generatedRule(@Nullable GeneratedRule generatedRule);
+        public abstract Builder generatedRuleClass(@Nullable Class<? extends GeneratedRule> klass);
+        public abstract Builder generatedRule(GeneratedRule instance);
 
         public abstract Rule build();
     }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/RuleAstBaseListener.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/RuleAstBaseListener.java
@@ -1,0 +1,364 @@
+package org.graylog.plugins.pipelineprocessor.ast;
+
+import org.graylog.plugins.pipelineprocessor.ast.expressions.AdditionExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.AndExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.ArrayLiteralExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.BinaryExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.BooleanExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.BooleanValuedFunctionWrapper;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.ComparisonExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.ConstantExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.DoubleExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.EqualityExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.Expression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.FieldAccessExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.FieldRefExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.FunctionExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.IndexedAccessExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.LogicalExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.LongExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.MapLiteralExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.MessageRefExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.MultiplicationExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.NotExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.NumericExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.OrExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.SignedExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.StringExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.UnaryExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.VarRefExpression;
+import org.graylog.plugins.pipelineprocessor.ast.statements.FunctionStatement;
+import org.graylog.plugins.pipelineprocessor.ast.statements.Statement;
+import org.graylog.plugins.pipelineprocessor.ast.statements.VarAssignStatement;
+
+public class RuleAstBaseListener implements RuleAstListener {
+    @Override
+    public void enterRule(Rule rule) {
+
+    }
+
+    @Override
+    public void exitRule(Rule rule) {
+
+    }
+
+    @Override
+    public void enterWhen(Rule rule) {
+
+    }
+
+    @Override
+    public void exitWhen(Rule rule) {
+
+    }
+
+    @Override
+    public void enterThen(Rule rule) {
+
+    }
+
+    @Override
+    public void exitThen(Rule rule) {
+
+    }
+
+    @Override
+    public void enterStatement(Statement statement) {
+
+    }
+
+    @Override
+    public void exitStatement(Statement statement) {
+
+    }
+
+    @Override
+    public void enterFunctionCallStatement(FunctionStatement func) {
+
+    }
+
+    @Override
+    public void exitFunctionCallStatement(FunctionStatement func) {
+
+    }
+
+    @Override
+    public void enterVariableAssignStatement(VarAssignStatement assign) {
+
+    }
+
+    @Override
+    public void exitVariableAssignStatement(VarAssignStatement assign) {
+
+    }
+
+    @Override
+    public void enterAddition(AdditionExpression expr) {
+
+    }
+
+    @Override
+    public void exitAddition(AdditionExpression expr) {
+
+    }
+
+    @Override
+    public void enterAnd(AndExpression expr) {
+
+    }
+
+    @Override
+    public void exitAnd(AndExpression expr) {
+
+    }
+
+    @Override
+    public void enterArrayLiteral(ArrayLiteralExpression expr) {
+
+    }
+
+    @Override
+    public void exitArrayLiteral(ArrayLiteralExpression expr) {
+
+    }
+
+    @Override
+    public void enterBinary(BinaryExpression expr) {
+
+    }
+
+    @Override
+    public void exitBinary(BinaryExpression expr) {
+
+    }
+
+    @Override
+    public void enterBoolean(BooleanExpression expr) {
+
+    }
+
+    @Override
+    public void exitBoolean(BooleanExpression expr) {
+
+    }
+
+    @Override
+    public void enterBooleanFuncWrapper(BooleanValuedFunctionWrapper expr) {
+
+    }
+
+    @Override
+    public void exitBooleanFuncWrapper(BooleanValuedFunctionWrapper expr) {
+
+    }
+
+    @Override
+    public void enterComparison(ComparisonExpression expr) {
+
+    }
+
+    @Override
+    public void exitComparison(ComparisonExpression expr) {
+
+    }
+
+    @Override
+    public void enterConstant(ConstantExpression expr) {
+
+    }
+
+    @Override
+    public void exitConstant(ConstantExpression expr) {
+
+    }
+
+    @Override
+    public void enterDouble(DoubleExpression expr) {
+
+    }
+
+    @Override
+    public void exitDouble(DoubleExpression expr) {
+
+    }
+
+    @Override
+    public void enterEquality(EqualityExpression expr) {
+
+    }
+
+    @Override
+    public void exitEquality(EqualityExpression expr) {
+
+    }
+
+    @Override
+    public void enterFieldAccess(FieldAccessExpression expr) {
+
+    }
+
+    @Override
+    public void exitFieldAccess(FieldAccessExpression expr) {
+
+    }
+
+    @Override
+    public void enterFieldRef(FieldRefExpression expr) {
+
+    }
+
+    @Override
+    public void exitFieldRef(FieldRefExpression expr) {
+
+    }
+
+    @Override
+    public void enterFunctionCall(FunctionExpression expr) {
+
+    }
+
+    @Override
+    public void exitFunctionCall(FunctionExpression expr) {
+
+    }
+
+    @Override
+    public void enterIndexedAccess(IndexedAccessExpression expr) {
+
+    }
+
+    @Override
+    public void exitIndexedAccess(IndexedAccessExpression expr) {
+
+    }
+
+    @Override
+    public void enterLogical(LogicalExpression expr) {
+
+    }
+
+    @Override
+    public void exitLogical(LogicalExpression expr) {
+
+    }
+
+    @Override
+    public void enterLong(LongExpression expr) {
+
+    }
+
+    @Override
+    public void exitLong(LongExpression expr) {
+
+    }
+
+    @Override
+    public void enterMapLiteral(MapLiteralExpression expr) {
+
+    }
+
+    @Override
+    public void exitMapLiteral(MapLiteralExpression expr) {
+
+    }
+
+    @Override
+    public void enterMessageRef(MessageRefExpression expr) {
+
+    }
+
+    @Override
+    public void exitMessageRef(MessageRefExpression expr) {
+
+    }
+
+    @Override
+    public void enterMultiplication(MultiplicationExpression expr) {
+
+    }
+
+    @Override
+    public void exitMultiplication(MultiplicationExpression expr) {
+
+    }
+
+    @Override
+    public void enterNot(NotExpression expr) {
+
+    }
+
+    @Override
+    public void exitNot(NotExpression expr) {
+
+    }
+
+    @Override
+    public void enterNumeric(NumericExpression expr) {
+
+    }
+
+    @Override
+    public void exitNumeric(NumericExpression expr) {
+
+    }
+
+    @Override
+    public void enterOr(OrExpression expr) {
+
+    }
+
+    @Override
+    public void exitOr(OrExpression expr) {
+
+    }
+
+    @Override
+    public void enterSigned(SignedExpression expr) {
+
+    }
+
+    @Override
+    public void exitSigned(SignedExpression expr) {
+
+    }
+
+    @Override
+    public void enterString(StringExpression expr) {
+
+    }
+
+    @Override
+    public void exitString(StringExpression expr) {
+
+    }
+
+    @Override
+    public void enterUnary(UnaryExpression expr) {
+
+    }
+
+    @Override
+    public void exitUnary(UnaryExpression expr) {
+
+    }
+
+    @Override
+    public void enterVariableReference(VarRefExpression expr) {
+
+    }
+
+    @Override
+    public void exitVariableReference(VarRefExpression expr) {
+
+    }
+
+    @Override
+    public void enterEveryExpression(Expression expr) {
+
+    }
+
+    @Override
+    public void exitEveryExpression(Expression expr) {
+
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/RuleAstBaseListener.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/RuleAstBaseListener.java
@@ -361,4 +361,14 @@ public class RuleAstBaseListener implements RuleAstListener {
     public void exitEveryExpression(Expression expr) {
 
     }
+
+    @Override
+    public void enterFunctionArg(FunctionExpression functionExpression, Expression expression) {
+
+    }
+
+    @Override
+    public void exitFunctionArg(Expression expression) {
+
+    }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/RuleAstListener.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/RuleAstListener.java
@@ -1,0 +1,169 @@
+package org.graylog.plugins.pipelineprocessor.ast;
+
+import org.graylog.plugins.pipelineprocessor.ast.expressions.AdditionExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.AndExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.ArrayLiteralExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.BinaryExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.BooleanExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.BooleanValuedFunctionWrapper;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.ComparisonExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.ConstantExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.DoubleExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.EqualityExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.Expression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.FieldAccessExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.FieldRefExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.FunctionExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.IndexedAccessExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.LogicalExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.LongExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.MapLiteralExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.MessageRefExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.MultiplicationExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.NotExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.NumericExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.OrExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.SignedExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.StringExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.UnaryExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.VarRefExpression;
+import org.graylog.plugins.pipelineprocessor.ast.statements.FunctionStatement;
+import org.graylog.plugins.pipelineprocessor.ast.statements.Statement;
+import org.graylog.plugins.pipelineprocessor.ast.statements.VarAssignStatement;
+
+/**
+ * Consider using RuleAstBaseListener to only implement the callbacks relevant to you.
+ */
+public interface RuleAstListener {
+    void enterRule(Rule rule);
+
+    void exitRule(Rule rule);
+
+    void enterWhen(Rule rule);
+
+    void exitWhen(Rule rule);
+
+    void enterThen(Rule rule);
+
+    void exitThen(Rule rule);
+
+    void enterStatement(Statement statement);
+
+    void exitStatement(Statement statement);
+
+    void enterFunctionCallStatement(FunctionStatement func);
+
+    void exitFunctionCallStatement(FunctionStatement func);
+
+    void enterVariableAssignStatement(VarAssignStatement assign);
+
+    void exitVariableAssignStatement(VarAssignStatement assign);
+
+    void enterAddition(AdditionExpression expr);
+
+    void exitAddition(AdditionExpression expr);
+
+    void enterAnd(AndExpression expr);
+
+    void exitAnd(AndExpression expr);
+
+    void enterArrayLiteral(ArrayLiteralExpression expr);
+
+    void exitArrayLiteral(ArrayLiteralExpression expr);
+
+    void enterBinary(BinaryExpression expr);
+
+    void exitBinary(BinaryExpression expr);
+
+    void enterBoolean(BooleanExpression expr);
+
+    void exitBoolean(BooleanExpression expr);
+
+    void enterBooleanFuncWrapper(BooleanValuedFunctionWrapper expr);
+
+    void exitBooleanFuncWrapper(BooleanValuedFunctionWrapper expr);
+
+    void enterComparison(ComparisonExpression expr);
+
+    void exitComparison(ComparisonExpression expr);
+
+    void enterConstant(ConstantExpression expr);
+
+    void exitConstant(ConstantExpression expr);
+
+    void enterDouble(DoubleExpression expr);
+
+    void exitDouble(DoubleExpression expr);
+
+    void enterEquality(EqualityExpression expr);
+
+    void exitEquality(EqualityExpression expr);
+
+    void enterFieldAccess(FieldAccessExpression expr);
+
+    void exitFieldAccess(FieldAccessExpression expr);
+
+    void enterFieldRef(FieldRefExpression expr);
+
+    void exitFieldRef(FieldRefExpression expr);
+
+    void enterFunctionCall(FunctionExpression expr);
+
+    void exitFunctionCall(FunctionExpression expr);
+
+    void enterIndexedAccess(IndexedAccessExpression expr);
+
+    void exitIndexedAccess(IndexedAccessExpression expr);
+
+    void enterLogical(LogicalExpression expr);
+
+    void exitLogical(LogicalExpression expr);
+
+    void enterLong(LongExpression expr);
+
+    void exitLong(LongExpression expr);
+
+    void enterMapLiteral(MapLiteralExpression expr);
+
+    void exitMapLiteral(MapLiteralExpression expr);
+
+    void enterMessageRef(MessageRefExpression expr);
+
+    void exitMessageRef(MessageRefExpression expr);
+
+    void enterMultiplication(MultiplicationExpression expr);
+
+    void exitMultiplication(MultiplicationExpression expr);
+
+    void enterNot(NotExpression expr);
+
+    void exitNot(NotExpression expr);
+
+    void enterNumeric(NumericExpression expr);
+
+    void exitNumeric(NumericExpression expr);
+
+    void enterOr(OrExpression expr);
+
+    void exitOr(OrExpression expr);
+
+    void enterSigned(SignedExpression expr);
+
+    void exitSigned(SignedExpression expr);
+
+    void enterString(StringExpression expr);
+
+    void exitString(StringExpression expr);
+
+    void enterUnary(UnaryExpression expr);
+
+    void exitUnary(UnaryExpression expr);
+
+    void enterVariableReference(VarRefExpression expr);
+
+    void exitVariableReference(VarRefExpression expr);
+
+    void enterEveryExpression(Expression expr);
+
+    void exitEveryExpression(Expression expr);
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/RuleAstListener.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/RuleAstListener.java
@@ -166,4 +166,8 @@ public interface RuleAstListener {
     void enterEveryExpression(Expression expr);
 
     void exitEveryExpression(Expression expr);
+
+    void enterFunctionArg(FunctionExpression functionExpression, Expression expression);
+
+    void exitFunctionArg(Expression expression);
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/RuleAstWalker.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/RuleAstWalker.java
@@ -1,0 +1,247 @@
+package org.graylog.plugins.pipelineprocessor.ast;
+
+import org.graylog.plugins.pipelineprocessor.ast.expressions.AdditionExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.AndExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.ArrayLiteralExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.BinaryExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.BooleanExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.BooleanValuedFunctionWrapper;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.ComparisonExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.ConstantExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.DoubleExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.EqualityExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.Expression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.FieldAccessExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.FieldRefExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.FunctionExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.IndexedAccessExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.LogicalExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.LongExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.MapLiteralExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.MessageRefExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.MultiplicationExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.NotExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.NumericExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.OrExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.SignedExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.StringExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.UnaryExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.VarRefExpression;
+import org.graylog.plugins.pipelineprocessor.ast.statements.FunctionStatement;
+import org.graylog.plugins.pipelineprocessor.ast.statements.Statement;
+import org.graylog.plugins.pipelineprocessor.ast.statements.VarAssignStatement;
+
+import java.util.Collection;
+
+public class RuleAstWalker {
+
+    public void walk(RuleAstListener listener, Rule rule) {
+        listener.enterRule(rule);
+
+        listener.enterWhen(rule);
+
+        walkExpression(listener, rule.when());
+
+        listener.exitWhen(rule);
+
+        listener.enterThen(rule);
+
+        walkStatements(listener, rule.then());
+
+        listener.exitThen(rule);
+
+        listener.exitRule(rule);
+    }
+
+    private void walkExpression(RuleAstListener listener, Expression expr) {
+        listener.enterEveryExpression(expr);
+        triggerAbstractEnter(listener, expr);
+        switch (expr.nodeType()) {
+            case ADD:
+                listener.enterAddition((AdditionExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitAddition((AdditionExpression) expr);
+                break;
+            case AND:
+                listener.enterAnd((AndExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitAnd((AndExpression) expr);
+                break;
+            case ARRAY_LITERAL:
+                listener.enterArrayLiteral((ArrayLiteralExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitArrayLiteral((ArrayLiteralExpression) expr);
+                break;
+            case BINARY:
+                // special, handled as wrapper type in triggerAbstractEnter/Exit
+                break;
+            case BOOLEAN:
+                listener.enterBoolean((BooleanExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitBoolean((BooleanExpression) expr);
+                break;
+            case BOOLEAN_FUNC_WRAPPER:
+                listener.enterBooleanFuncWrapper((BooleanValuedFunctionWrapper) expr);
+                visitChildren(listener, expr);
+                listener.exitBooleanFuncWrapper((BooleanValuedFunctionWrapper) expr);
+                break;
+            case COMPARISON:
+                listener.enterComparison((ComparisonExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitComparison((ComparisonExpression) expr);
+                break;
+            case CONSTANT:
+                // special, handled as wrapper type in triggerAbstractEnter/Exit
+                break;
+            case DOUBLE:
+                listener.enterDouble((DoubleExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitDouble((DoubleExpression) expr);
+                break;
+            case EQUALITY:
+                listener.enterEquality((EqualityExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitEquality((EqualityExpression) expr);
+                break;
+            case FIELD_ACCESS:
+                listener.enterFieldAccess((FieldAccessExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitFieldAccess((FieldAccessExpression) expr);
+                break;
+            case FIELD_REF:
+                listener.enterFieldRef((FieldRefExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitFieldRef((FieldRefExpression) expr);
+                break;
+            case FUNCTION:
+                listener.enterFunctionCall((FunctionExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitFunctionCall((FunctionExpression) expr);
+                break;
+            case INDEXED_ACCESS:
+                listener.enterIndexedAccess((IndexedAccessExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitIndexedAccess((IndexedAccessExpression) expr);
+                break;
+            case LOGICAL:
+                // special, handled as wrapper type in triggerAbstractEnter/Exit
+                break;
+            case LONG:
+                listener.enterLong((LongExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitLong((LongExpression) expr);
+                break;
+            case MAP_LITERAL:
+                listener.enterMapLiteral((MapLiteralExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitMapLiteral((MapLiteralExpression) expr);
+                break;
+            case MESSAGE:
+                listener.enterMessageRef((MessageRefExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitMessageRef((MessageRefExpression) expr);
+                break;
+            case MULT:
+                listener.enterMultiplication((MultiplicationExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitMultiplication((MultiplicationExpression) expr);
+                break;
+            case NOT:
+                listener.enterNot((NotExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitNot((NotExpression) expr);
+                break;
+            case NUMERIC:
+                // special, handled as wrapper type in triggerAbstractEnter/Exit
+                break;
+            case OR:
+                listener.enterOr((OrExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitOr((OrExpression) expr);
+                break;
+            case SIGNED:
+                listener.enterSigned((SignedExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitSigned((SignedExpression) expr);
+                break;
+            case STRING:
+                listener.enterString((StringExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitString((StringExpression) expr);
+                break;
+            case UNARY:
+                // special, handled as wrapper type in triggerAbstractEnter/Exit
+                break;
+            case VAR_REF:
+                listener.enterVariableReference((VarRefExpression) expr);
+                visitChildren(listener, expr);
+                listener.exitVariableReference((VarRefExpression) expr);
+                break;
+        }
+        triggerAbstractExit(listener, expr);
+        listener.exitEveryExpression(expr);
+    }
+
+    private void triggerAbstractEnter(RuleAstListener listener, Expression expr) {
+        
+        if (expr instanceof BinaryExpression) {
+            listener.enterBinary((BinaryExpression) expr);
+            
+        } else if (expr instanceof UnaryExpression) { // must not be first in "else if" because "binary is instanceof unary" 
+            listener.enterUnary((UnaryExpression) expr);
+        }
+        // for the others we trigger regardless whether it's a binary or unary expr
+        if (expr instanceof LogicalExpression) {
+            listener.enterLogical((LogicalExpression) expr);
+        }
+        if (expr instanceof NumericExpression) {
+            listener.enterNumeric((NumericExpression) expr);
+        }
+        if (expr instanceof ConstantExpression) {
+            listener.enterConstant((ConstantExpression) expr);
+        }
+    }
+
+    private void triggerAbstractExit(RuleAstListener listener, Expression expr) {
+        if (expr instanceof BinaryExpression) {
+            listener.exitBinary((BinaryExpression) expr);
+
+        } else if (expr instanceof UnaryExpression) { // must not be first in "else if" because "binary is instanceof unary" 
+            listener.exitUnary((UnaryExpression) expr);
+        }
+        // for the others we trigger regardless whether it's a binary or unary expr
+        if (expr instanceof LogicalExpression) {
+            listener.exitLogical((LogicalExpression) expr);
+        }
+        if (expr instanceof NumericExpression) {
+            listener.exitNumeric((NumericExpression) expr);
+        }
+        if (expr instanceof ConstantExpression) {
+            listener.exitConstant((ConstantExpression) expr);
+        }
+    }
+
+    private void visitChildren(RuleAstListener listener, Expression expr) {
+        expr.children().forEach(expression -> walkExpression(listener, expression));
+    }
+
+    private void walkStatements(RuleAstListener listener, Collection<Statement> statements) {
+        statements.forEach(statement -> {
+            listener.enterStatement(statement);
+
+            if (statement instanceof FunctionStatement) {
+                FunctionStatement func = (FunctionStatement) statement;
+                listener.enterFunctionCallStatement(func);
+                walkExpression(listener, func.getFunctionExpression());
+                listener.exitFunctionCallStatement(func);
+            } else if (statement instanceof VarAssignStatement) {
+                VarAssignStatement assign = (VarAssignStatement) statement;
+                listener.enterVariableAssignStatement(assign);
+                walkExpression(listener, assign.getValueExpression());
+                listener.exitVariableAssignStatement(assign);
+            }
+
+            listener.exitStatement(statement);
+        });
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/RuleAstWalker.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/RuleAstWalker.java
@@ -115,7 +115,14 @@ public class RuleAstWalker {
                 break;
             case FUNCTION:
                 listener.enterFunctionCall((FunctionExpression) expr);
-                visitChildren(listener, expr);
+                // special case, we want to wrap each function argument's expressing into its own
+                // callback, so we can generate statements for them.
+                expr.children().forEach(expression -> {
+                    listener.enterFunctionArg((FunctionExpression) expr, expression);
+                    walkExpression(listener, expression);
+                    listener.exitFunctionArg(expression);
+                });
+
                 listener.exitFunctionCall((FunctionExpression) expr);
                 break;
             case INDEXED_ACCESS:

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/AdditionExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/AdditionExpression.java
@@ -72,6 +72,10 @@ public class AdditionExpression extends BinaryExpression implements NumericExpre
         }
     }
 
+    public boolean isPlus() {
+        return isPlus;
+    }
+
     @Override
     public Class getType() {
         return type;

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/ArrayLiteralExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/ArrayLiteralExpression.java
@@ -17,6 +17,8 @@
 package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+
 import org.antlr.v4.runtime.Token;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 
@@ -37,7 +39,7 @@ public class ArrayLiteralExpression extends BaseExpression {
     }
 
     @Override
-    public Object evaluateUnsafe(EvaluationContext context) {
+    public List evaluateUnsafe(EvaluationContext context) {
         return  elements.stream()
                 .map(expression -> expression.evaluateUnsafe(context))
                 .collect(Collectors.toList());
@@ -51,5 +53,10 @@ public class ArrayLiteralExpression extends BaseExpression {
     @Override
     public String toString() {
         return "[" + Joiner.on(", ").join(elements) + "]";
+    }
+
+    @Override
+    public Iterable<Expression> children() {
+        return ImmutableList.copyOf(elements);
     }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/BinaryExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/BinaryExpression.java
@@ -16,11 +16,13 @@
  */
 package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
+import com.google.common.collect.ImmutableList;
+
 import org.antlr.v4.runtime.Token;
 
 public abstract class BinaryExpression extends UnaryExpression {
 
-    protected final Expression left;
+    protected Expression left;
 
     public BinaryExpression(Token start, Expression left, Expression right) {
         super(start, right);
@@ -34,5 +36,13 @@ public abstract class BinaryExpression extends UnaryExpression {
 
     public Expression left() {
         return left;
+    }
+
+    public void left(Expression left) {
+        this.left = left;
+    }
+    @Override
+    public Iterable<Expression> children() {
+        return ImmutableList.of(left, right);
     }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/BooleanValuedFunctionWrapper.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/BooleanValuedFunctionWrapper.java
@@ -19,6 +19,8 @@ package org.graylog.plugins.pipelineprocessor.ast.expressions;
 import org.antlr.v4.runtime.Token;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 
+import java.util.Collections;
+
 public class BooleanValuedFunctionWrapper extends BaseExpression implements LogicalExpression {
     private final Expression expr;
 
@@ -51,8 +53,17 @@ public class BooleanValuedFunctionWrapper extends BaseExpression implements Logi
         return expr.getType();
     }
 
+    public Expression expression() {
+        return expr;
+    }
+
     @Override
     public String toString() {
         return expr.toString();
+    }
+
+    @Override
+    public Iterable<Expression> children() {
+        return Collections.singleton(expr);
     }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/ComparisonExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/ComparisonExpression.java
@@ -101,6 +101,10 @@ public class ComparisonExpression extends BinaryExpression implements LogicalExp
         }
     }
 
+    public String getOperator() {
+        return operator;
+    }
+
     @Override
     public String toString() {
         return left.toString() + " " + operator + " " + right.toString();

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/ConstantExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/ConstantExpression.java
@@ -18,6 +18,8 @@ package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
 import org.antlr.v4.runtime.Token;
 
+import java.util.Collections;
+
 public abstract class ConstantExpression extends BaseExpression {
 
     private final Class type;
@@ -37,4 +39,8 @@ public abstract class ConstantExpression extends BaseExpression {
         return type;
     }
 
+    @Override
+    public Iterable<Expression> children() {
+        return Collections.emptySet();
+    }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/EqualityExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/EqualityExpression.java
@@ -77,6 +77,10 @@ public class EqualityExpression extends BinaryExpression implements LogicalExpre
                   checkEquality == equals, this.left, this.right, left, right);
     }
 
+    public boolean isCheckEquality() {
+        return checkEquality;
+    }
+
     @Override
     public String toString() {
         return left.toString() + (checkEquality ? " == " : " != ") + right.toString();

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/Expression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/Expression.java
@@ -16,9 +16,14 @@
  */
 package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Maps;
+
 import org.antlr.v4.runtime.Token;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.exceptions.FunctionEvaluationException;
+
+import java.util.Map;
 
 import javax.annotation.Nullable;
 
@@ -48,8 +53,70 @@ public interface Expression {
     Class getType();
 
     /**
-     * This method is allow to throw exceptions. The outside world is supposed to call evaluate instead.
+     * This method is allowed to throw exceptions. The outside world is supposed to call evaluate instead.
      */
     @Nullable
     Object evaluateUnsafe(EvaluationContext context);
+
+    /**
+     * This method is allowed to throw exceptions and evaluates the expression in an empty context.
+     * It is only useful for the interpreter/code generator to evaluate constant expressions to their effective value.
+     *
+     * @return the value of the expression in an empty context
+     */
+    default Object evaluateUnsafe() {
+        return evaluateUnsafe(EvaluationContext.emptyContext());
+    }
+
+    Iterable<Expression> children();
+
+    default Type nodeType() {
+        return Type.fromClass(this.getClass());
+    }
+
+    // helper to aid switching over the available expression node types
+    enum Type {
+        ADD(AdditionExpression.class),
+        AND(AndExpression.class),
+        ARRAY_LITERAL(ArrayLiteralExpression.class),
+        BINARY(BinaryExpression.class),
+        BOOLEAN(BooleanExpression.class),
+        BOOLEAN_FUNC_WRAPPER(BooleanValuedFunctionWrapper.class),
+        COMPARISON(ComparisonExpression.class),
+        CONSTANT(ConstantExpression.class),
+        DOUBLE(DoubleExpression.class),
+        EQUALITY(EqualityExpression.class),
+        FIELD_ACCESS(FieldAccessExpression.class),
+        FIELD_REF(FieldRefExpression.class),
+        FUNCTION(FunctionExpression.class),
+        INDEXED_ACCESS(IndexedAccessExpression.class),
+        LOGICAL(LogicalExpression.class),
+        LONG(LongExpression.class),
+        MAP_LITERAL(MapLiteralExpression.class),
+        MESSAGE(MessageRefExpression.class),
+        MULT(MultiplicationExpression.class),
+        NOT(NotExpression.class),
+        NUMERIC(NumericExpression.class),
+        OR(OrExpression.class),
+        SIGNED(SignedExpression.class),
+        STRING(StringExpression.class),
+        UNARY(UnaryExpression.class),
+        VAR_REF(VarRefExpression.class);
+
+        static Map<Class, Type> classMap;
+
+        static {
+            classMap = Maps.uniqueIndex(Iterators.forArray(Type.values()), type -> type.klass);
+        }
+
+        private final Class<? extends Expression> klass;
+
+        Type(Class<? extends Expression> expressionClass) {
+            klass = expressionClass;
+        }
+
+        static Type fromClass(Class klass) {
+            return classMap.get(klass);
+        }
+    }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/FieldAccessExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/FieldAccessExpression.java
@@ -16,6 +16,8 @@
  */
 package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
+import com.google.common.collect.ImmutableList;
+
 import org.antlr.v4.runtime.Token;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
@@ -71,5 +73,18 @@ public class FieldAccessExpression extends BaseExpression {
     @Override
     public String toString() {
         return object.toString() + "." + field.toString();
+    }
+
+    public Expression object() {
+        return object;
+    }
+
+    public Expression field() {
+        return field;
+    }
+
+    @Override
+    public Iterable<Expression> children() {
+        return ImmutableList.of(object, field);
     }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/FieldRefExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/FieldRefExpression.java
@@ -19,6 +19,8 @@ package org.graylog.plugins.pipelineprocessor.ast.expressions;
 import org.antlr.v4.runtime.Token;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 
+import java.util.Collections;
+
 public class FieldRefExpression extends BaseExpression {
     private final String variableName;
 
@@ -45,5 +47,14 @@ public class FieldRefExpression extends BaseExpression {
     @Override
     public String toString() {
         return variableName;
+    }
+
+    public String fieldName() {
+        return variableName;
+    }
+
+    @Override
+    public Iterable<Expression> children() {
+        return Collections.emptySet();
     }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/FieldRefExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/FieldRefExpression.java
@@ -23,10 +23,12 @@ import java.util.Collections;
 
 public class FieldRefExpression extends BaseExpression {
     private final String variableName;
+    private final Expression fieldExpr;
 
-    public FieldRefExpression(Token start, String variableName) {
+    public FieldRefExpression(Token start, String variableName, Expression fieldExpr) {
         super(start);
         this.variableName = variableName;
+        this.fieldExpr = fieldExpr;
     }
 
     @Override

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/FunctionExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/FunctionExpression.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
 import com.google.common.base.Joiner;
+
 import org.antlr.v4.runtime.Token;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.exceptions.FunctionEvaluationException;
@@ -24,6 +25,9 @@ import org.graylog.plugins.pipelineprocessor.ast.exceptions.LocationAwareEvalExc
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class FunctionExpression extends BaseExpression {
     private final FunctionArgs args;
@@ -82,5 +86,10 @@ public class FunctionExpression extends BaseExpression {
                                   .iterator());
         }
         return descriptor.name() + "(" + argsString + ")";
+    }
+
+    @Override
+    public Iterable<Expression> children() {
+        return args.getArgs().entrySet().stream().map(Map.Entry::getValue).collect(Collectors.toList());
     }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/IndexedAccessExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/IndexedAccessExpression.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.primitives.Ints;
 import org.antlr.v4.runtime.Token;
@@ -84,5 +85,10 @@ public class IndexedAccessExpression extends BaseExpression {
 
     public Expression getIndex() {
         return index;
+    }
+
+    @Override
+    public Iterable<Expression> children() {
+        return ImmutableList.of(indexableObject, index);
     }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/MapLiteralExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/MapLiteralExpression.java
@@ -17,6 +17,8 @@
 package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+
 import org.antlr.v4.runtime.Token;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.jooq.lambda.Seq;
@@ -39,7 +41,7 @@ public class MapLiteralExpression extends BaseExpression {
     }
 
     @Override
-    public Object evaluateUnsafe(EvaluationContext context) {
+    public Map evaluateUnsafe(EvaluationContext context) {
         // evaluate all values for each key and return the resulting map
         return Seq.seq(map)
                 .map(entry -> entry.map2(value -> value.evaluateUnsafe(context)))
@@ -54,5 +56,10 @@ public class MapLiteralExpression extends BaseExpression {
     @Override
     public String toString() {
         return "{" + Joiner.on(", ").withKeyValueSeparator(":").join(map) + "}";
+    }
+
+    @Override
+    public Iterable<Expression> children() {
+        return ImmutableList.copyOf(map.values());
     }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/MapLiteralExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/MapLiteralExpression.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import org.antlr.v4.runtime.Token;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
@@ -56,6 +57,10 @@ public class MapLiteralExpression extends BaseExpression {
     @Override
     public String toString() {
         return "{" + Joiner.on(", ").withKeyValueSeparator(":").join(map) + "}";
+    }
+
+    public Iterable<Map.Entry<String, Expression>> entries() {
+        return ImmutableSet.copyOf(map.entrySet());
     }
 
     @Override

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/MessageRefExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/MessageRefExpression.java
@@ -19,6 +19,8 @@ package org.graylog.plugins.pipelineprocessor.ast.expressions;
 import org.antlr.v4.runtime.Token;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 
+import java.util.Collections;
+
 public class MessageRefExpression extends BaseExpression {
     private final Expression fieldExpr;
 
@@ -53,5 +55,10 @@ public class MessageRefExpression extends BaseExpression {
 
     public Expression getFieldExpr() {
         return fieldExpr;
+    }
+
+    @Override
+    public Iterable<Expression> children() {
+        return Collections.singleton(fieldExpr);
     }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/MultiplicationExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/MultiplicationExpression.java
@@ -84,6 +84,10 @@ public class MultiplicationExpression extends BinaryExpression implements Numeri
         }
     }
 
+    public char getOperator() {
+        return operator;
+    }
+
     @Override
     public Class getType() {
         return type;

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/SignedExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/SignedExpression.java
@@ -67,4 +67,7 @@ public class SignedExpression extends UnaryExpression implements NumericExpressi
         return (isPlus ? " + " : " - ") + right.toString();
     }
 
+    public boolean isPlus() {
+        return isPlus;
+    }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/UnaryExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/UnaryExpression.java
@@ -18,9 +18,11 @@ package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
 import org.antlr.v4.runtime.Token;
 
+import java.util.Collections;
+
 public abstract class UnaryExpression extends BaseExpression {
 
-    protected final Expression right;
+    protected Expression right;
 
     public UnaryExpression(Token start, Expression right) {
         super(start);
@@ -39,5 +41,14 @@ public abstract class UnaryExpression extends BaseExpression {
 
     public Expression right() {
         return right;
+    }
+
+    public void right(Expression right) {
+        this.right = right;
+    }
+
+    @Override
+    public Iterable<Expression> children() {
+        return Collections.singleton(right);
     }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/VarRefExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/VarRefExpression.java
@@ -26,16 +26,18 @@ import java.util.Collections;
 public class VarRefExpression extends BaseExpression {
     private static final Logger log = LoggerFactory.getLogger(VarRefExpression.class);
     private final String identifier;
+    private final Expression varExpr;
     private Class type = Object.class;
 
-    public VarRefExpression(Token start, String identifier) {
+    public VarRefExpression(Token start, String identifier, Expression varExpr) {
         super(start);
         this.identifier = identifier;
+        this.varExpr = varExpr;
     }
 
     @Override
     public boolean isConstant() {
-        return false;
+        return varExpr != null && varExpr.isConstant();
     }
 
     @Override
@@ -61,6 +63,8 @@ public class VarRefExpression extends BaseExpression {
     public String varName() {
         return identifier;
     }
+
+    public Expression varExpr() { return varExpr; }
 
     public void setType(Class type) {
         this.type = type;

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/VarRefExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/VarRefExpression.java
@@ -21,6 +21,8 @@ import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+
 public class VarRefExpression extends BaseExpression {
     private static final Logger log = LoggerFactory.getLogger(VarRefExpression.class);
     private final String identifier;
@@ -62,5 +64,10 @@ public class VarRefExpression extends BaseExpression {
 
     public void setType(Class type) {
         this.type = type;
+    }
+
+    @Override
+    public Iterable<Expression> children() {
+        return Collections.emptySet();
     }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/functions/FunctionArgs.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/functions/FunctionArgs.java
@@ -19,6 +19,7 @@ package org.graylog.plugins.pipelineprocessor.ast.functions;
 import com.google.common.collect.Maps;
 
 import org.graylog.plugins.pipelineprocessor.ast.expressions.Expression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.VarRefExpression;
 
 import java.util.Collections;
 import java.util.Map;
@@ -54,6 +55,7 @@ public class FunctionArgs {
     public Map<String, Expression> getConstantArgs() {
         return args.entrySet().stream()
                 .filter(e -> e.getValue().isConstant())
+                .filter(e -> !(e.getValue() instanceof VarRefExpression)) // do not eagerly touch variables
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/functions/FunctionArgs.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/functions/FunctionArgs.java
@@ -17,14 +17,16 @@
 package org.graylog.plugins.pipelineprocessor.ast.functions;
 
 import com.google.common.collect.Maps;
+
 import org.graylog.plugins.pipelineprocessor.ast.expressions.Expression;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/functions/ParameterDescriptor.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/functions/ParameterDescriptor.java
@@ -16,15 +16,18 @@
  */
 package org.graylog.plugins.pipelineprocessor.ast.functions;
 
+import com.google.auto.value.AutoValue;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.auto.value.AutoValue;
+
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.expressions.Expression;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
+
+import javax.annotation.Nullable;
 
 @AutoValue
 @JsonAutoDetect

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/statements/FunctionStatement.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/statements/FunctionStatement.java
@@ -32,6 +32,10 @@ public class FunctionStatement implements Statement {
         return functionExpression.evaluate(context);
     }
 
+    public Expression getFunctionExpression() {
+        return functionExpression;
+    }
+
     @Override
     public String toString() {
         return functionExpression.toString();

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/statements/VarAssignStatement.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/statements/VarAssignStatement.java
@@ -35,6 +35,14 @@ public class VarAssignStatement implements Statement {
         return null;
     }
 
+    public String getName() {
+        return name;
+    }
+
+    public Expression getValueExpression() {
+        return expr;
+    }
+
     @Override
     public String toString() {
         return "let " + name + " = " + expr.toString();

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/codegen/CodeGenerator.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/codegen/CodeGenerator.java
@@ -1,0 +1,233 @@
+package org.graylog.plugins.pipelineprocessor.codegen;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Maps;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+
+import org.apache.commons.beanutils.PropertyUtils;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.Rule;
+import org.graylog.plugins.pipelineprocessor.ast.RuleAstBaseListener;
+import org.graylog.plugins.pipelineprocessor.ast.RuleAstWalker;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.AndExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.BooleanValuedFunctionWrapper;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.ConstantExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.EqualityExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.Expression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.FieldAccessExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.FieldRefExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.FunctionExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.NotExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.OrExpression;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.StringExpression;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.beans.FeatureDescriptor;
+import java.beans.PropertyDescriptor;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.annotation.Nonnull;
+import javax.lang.model.element.Modifier;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+public class CodeGenerator {
+    private static final Logger log = LoggerFactory.getLogger(CodeGenerator.class);
+    private static AtomicLong ruleNameCounter = new AtomicLong();
+
+    public static String codeForRule(Rule rule) {
+        final JavaPoetListener javaPoetListener = new JavaPoetListener();
+        new RuleAstWalker().walk(javaPoetListener, rule);
+        return javaPoetListener.getSource();
+    }
+
+    private static class JavaPoetListener extends RuleAstBaseListener {
+        private long counter = 0;
+        private IdentityHashMap<Expression, CodeBlock> codeSnippet = new IdentityHashMap<>();
+
+        private TypeSpec.Builder classFile;
+        private JavaFile generatedFile;
+        private MethodSpec.Builder when;
+        private MethodSpec.Builder then;
+
+        public String getSource() {
+            return generatedFile.toString();
+        }
+
+        @Override
+        public void enterRule(Rule rule) {
+            // generates a new ephemeral unique class name for each generated rule. Only valid for the runtime of the jvm
+            classFile = TypeSpec.classBuilder("rule$" + ruleNameCounter.incrementAndGet())
+                    .addSuperinterface(GeneratedRule.class)
+                    .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
+                    .addMethod(MethodSpec.methodBuilder("name")
+                            .returns(String.class)
+                            .addAnnotation(Override.class)
+                            .addStatement("return $S", rule.name())
+                            .build()
+                    );
+
+        }
+
+        @Override
+        public void exitRule(Rule rule) {
+            generatedFile = JavaFile.builder("org.graylog.plugins.pipelineprocessor.$dynamic.rules", classFile.build())
+                    .build();
+        }
+
+        @Override
+        public void enterWhen(Rule rule) {
+            when = MethodSpec.methodBuilder("when")
+                    .addModifiers(Modifier.PUBLIC)
+                    .addAnnotation(Override.class)
+                    .returns(boolean.class)
+                    .addParameter(EvaluationContext.class, "context", Modifier.FINAL)
+                    .addStatement("boolean $$when = false");
+        }
+
+        @Override
+        public void exitWhen(Rule rule) {
+            final CodeBlock result = codeSnippet.getOrDefault(rule.when(), CodeBlock.of("$$when"));
+            when.addStatement("return $L", result);
+
+            classFile.addMethod(when.build());
+        }
+
+        @Override
+        public void enterThen(Rule rule) {
+            then = MethodSpec.methodBuilder("then")
+                    .addModifiers(Modifier.PUBLIC)
+                    .addAnnotation(Override.class)
+                    .addParameter(EvaluationContext.class, "context", Modifier.FINAL);
+        }
+
+        @Override
+        public void exitThen(Rule rule) {
+            classFile.addMethod(then.build());
+        }
+
+        @Override
+        public void exitAnd(AndExpression expr) {
+            final CodeBlock left = codeSnippet.get(expr.left());
+            final CodeBlock right = codeSnippet.get(expr.right());
+
+            codeSnippet.put(expr, CodeBlock.of("$L && $L", blockOrMissing(left, expr.left()), blockOrMissing(right, expr.right())));
+        }
+
+        @Override
+        public void exitOr(OrExpression expr) {
+            final CodeBlock left = codeSnippet.get(expr.left());
+            final CodeBlock right = codeSnippet.get(expr.right());
+
+            codeSnippet.put(expr, CodeBlock.of("$L || $L", blockOrMissing(left, expr.left()), blockOrMissing(right, expr.right())));
+        }
+
+        @Override
+        public void exitNot(NotExpression expr) {
+            final CodeBlock right = codeSnippet.get(expr.right());
+
+            codeSnippet.put(expr, CodeBlock.of("!$L", blockOrMissing(right, expr.right())));
+        }
+
+        @Override
+        public void exitFieldRef(FieldRefExpression expr) {
+            codeSnippet.put(expr, CodeBlock.of("$L", expr.fieldName()));
+        }
+
+        @Override
+        public void exitFieldAccess(FieldAccessExpression expr) {
+            final CodeBlock object = codeSnippet.get(expr.object());
+            final CodeBlock field = codeSnippet.get(expr.field());
+
+            final Object objectRef = blockOrMissing(object, expr.object());
+
+            final Expression o = expr.object();
+            final PropertyDescriptor[] propertyDescriptors = PropertyUtils.getPropertyDescriptors(o.getType());
+            final ImmutableMap<String, PropertyDescriptor> propertyByName = Maps.uniqueIndex(Iterators.forArray(propertyDescriptors), FeatureDescriptor::getName);
+
+            final String fieldName = field.toString();
+            final CodeBlock block;
+            if (propertyByName.containsKey(fieldName)) {
+                // we have the property, resolve the read method name for it
+                final PropertyDescriptor descriptor = propertyByName.get(fieldName);
+                final String methodName = descriptor.getReadMethod().getName();
+                block = CodeBlock.of("$L.$L()", objectRef, methodName);
+            } else if (o instanceof Map) {
+                // there wasn't any property, but the object is a Map, translate into .get() call
+                block = CodeBlock.of("$L.get($S)", objectRef, field);
+            } else {
+                // this is basically an error, because we expected either a property to match or a map lookup.
+                log.warn("Unable to determine field accessor for property {}", field);
+                block = CodeBlock.of("null");
+            }
+
+            codeSnippet.put(expr, block);
+        }
+
+        @Override
+        public void exitFunctionCall(FunctionExpression expr) {
+            final String intermediateName = subExpressionName();
+            final FunctionDescriptor<?> function = expr.getFunction().descriptor();
+
+            final String funcReference = "func$" + function.name();
+            CodeBlock functionInvocation = CodeBlock.of("$L($L)", funcReference, null);
+
+            when.addStatement("$T $L = $L", ClassName.get(function.returnType()), intermediateName, functionInvocation);
+            codeSnippet.put(expr, CodeBlock.of("$L", intermediateName));
+        }
+
+        @Override
+        public void exitEquality(EqualityExpression expr) {
+            final String intermediateName = subExpressionName();
+
+            // equality is one of the points we generate intermediate values at
+            final CodeBlock leftBlock = codeSnippet.get(expr.left());
+            final CodeBlock rightBlock = codeSnippet.get(expr.right());
+            when.addStatement("boolean $L = $L == $L", intermediateName, blockOrMissing(leftBlock, expr.left()), blockOrMissing(rightBlock, expr.right()));
+            codeSnippet.put(expr, CodeBlock.of("$L", intermediateName));
+        }
+
+        @Override
+        public void exitBooleanFuncWrapper(BooleanValuedFunctionWrapper expr) {
+            final CodeBlock embeddedExpr = codeSnippet.get(expr.expression());
+
+            // simply forward the other expression's code
+            codeSnippet.put(expr, CodeBlock.of("$L", blockOrMissing(embeddedExpr, expr.expression())));
+        }
+
+        @Override
+        public void exitConstant(ConstantExpression expr) {
+            codeSnippet.putIfAbsent(expr, CodeBlock.of("$L", expr.evaluateUnsafe()));
+        }
+
+        @Override
+        public void exitString(StringExpression expr) {
+            // this overrides what exitConstant would do for strings…
+            codeSnippet.putIfAbsent(expr, CodeBlock.of("$S", expr.evaluateUnsafe()));
+        }
+
+        @Nonnull
+        private String subExpressionName() {
+            return "im$" + counter++;
+        }
+
+        private Object blockOrMissing(Object block, Expression fallBackExpression) {
+            if (block == null) {
+                log.warn("Missing code snippet for {}: ", fallBackExpression.nodeType(), fallBackExpression);
+            }
+            return firstNonNull(block, fallBackExpression);
+        }
+
+    }
+
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/codegen/CodeGenerator.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/codegen/CodeGenerator.java
@@ -67,12 +67,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
-import javax.inject.Inject;
 import javax.lang.model.element.Modifier;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -87,13 +85,11 @@ public class CodeGenerator {
     }
 
     @SuppressWarnings("unchecked")
-    public Class<? extends GeneratedRule> generateCompiledRule(Rule rule) {
+    public Class<? extends GeneratedRule> generateCompiledRule(Rule rule, ClassLoader ruleClassloader) {
         if (rule.id() == null) {
             throw new IllegalArgumentException("Rules must have an id to generate code for them");
         }
         final String sourceCode = sourceCodeForRule(rule);
-        ClassLoader ruleClassloader = new ClassLoader() {
-        };
         try {
             log.info("Sourcecode:\n{}", sourceCode);
             return (Class<GeneratedRule>) CompilerUtils.CACHED_COMPILER.loadFromJava(ruleClassloader, "org.graylog.plugins.pipelineprocessor.$dynamic.rules.rule$" + rule.id() , sourceCode);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/codegen/CodeGenerator.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/codegen/CodeGenerator.java
@@ -93,6 +93,7 @@ public class CodeGenerator {
         private Set<TypeSpec> functionArgsHolderTypes = Sets.newHashSet();
         private MethodSpec.Builder constructorBuilder;
         private CodeBlock.Builder lateConstructorBlock;
+        private Set<CodeBlock> functionReferences = Sets.newHashSet();
 
         public String getSource() {
             return generatedFile.toString();
@@ -128,8 +129,12 @@ public class CodeGenerator {
             // TODO these can be shared and should potentially created by an AnnotationProcessor for each defined function instead of every rule
             classFile.addTypes(functionArgsHolderTypes);
 
+            // resolve functions (but only do so once for each function)
+            functionReferences.forEach(block -> constructorBuilder.addStatement("$L", block));
             // add initializers for fields that depend on the functions being set
             constructorBuilder.addCode(lateConstructorBlock.build());
+
+
             classFile.addMethod(constructorBuilder.build());
 
             generatedFile = JavaFile.builder("org.graylog.plugins.pipelineprocessor.$dynamic.rules", classFile.build())
@@ -260,14 +265,15 @@ public class CodeGenerator {
             } else {
                 currentMethod.addStatement("$T $L = $L", ClassName.get(function.returnType()), functionValueVarName, functionInvocation);
             }
+            // create a field/initializer block for the function reference
             functionMembers.add(
-                    FieldSpec.builder(expr.getFunction().getClass(), mangledFunctionName, Modifier.PRIVATE)
+                    FieldSpec.builder(expr.getFunction().getClass(), mangledFunctionName, Modifier.PRIVATE, Modifier.FINAL)
                             .build());
-            codeSnippet.put(expr, CodeBlock.of("$L", functionValueVarName));
-            constructorBuilder.addStatement("$L = ($T) functionRegistry.resolve($S)",
+            functionReferences.add(CodeBlock.of("$L = ($T) functionRegistry.resolve($S)",
                     mangledFunctionName,
                     expr.getFunction().getClass(),
-                    function.name());
+                    function.name()));
+            codeSnippet.put(expr, CodeBlock.of("$L", functionValueVarName));
         }
 
         @Nonnull

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/codegen/GeneratedRule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/codegen/GeneratedRule.java
@@ -1,0 +1,13 @@
+package org.graylog.plugins.pipelineprocessor.codegen;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+
+public interface GeneratedRule {
+
+    String name();
+
+    boolean when(EvaluationContext context);
+
+    void then(EvaluationContext context);
+
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.pipelineprocessor.parser;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -70,6 +71,8 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.statements.FunctionStatement;
 import org.graylog.plugins.pipelineprocessor.ast.statements.Statement;
 import org.graylog.plugins.pipelineprocessor.ast.statements.VarAssignStatement;
+import org.graylog.plugins.pipelineprocessor.codegen.CodeGenerator;
+import org.graylog.plugins.pipelineprocessor.codegen.GeneratedRule;
 import org.graylog.plugins.pipelineprocessor.parser.errors.IncompatibleArgumentType;
 import org.graylog.plugins.pipelineprocessor.parser.errors.IncompatibleIndexType;
 import org.graylog.plugins.pipelineprocessor.parser.errors.IncompatibleType;
@@ -83,9 +86,12 @@ import org.graylog.plugins.pipelineprocessor.parser.errors.SyntaxError;
 import org.graylog.plugins.pipelineprocessor.parser.errors.UndeclaredFunction;
 import org.graylog.plugins.pipelineprocessor.parser.errors.UndeclaredVariable;
 import org.graylog.plugins.pipelineprocessor.parser.errors.WrongNumberOfArgs;
+import org.reflections.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -101,14 +107,26 @@ import static java.util.stream.Collectors.toList;
 public class PipelineRuleParser {
 
     private final FunctionRegistry functionRegistry;
+    private final CodeGenerator codeGenerator;
+
+    private static boolean allowCodeGeneration = false;
 
     @Inject
-    public PipelineRuleParser(FunctionRegistry functionRegistry) {
+    public PipelineRuleParser(FunctionRegistry functionRegistry, CodeGenerator codeGenerator) {
         this.functionRegistry = functionRegistry;
+        this.codeGenerator = codeGenerator;
     }
 
     private static final Logger log = LoggerFactory.getLogger(PipelineRuleParser.class);
     public static final ParseTreeWalker WALKER = ParseTreeWalker.DEFAULT;
+
+    public static boolean isAllowCodeGeneration() {
+        return allowCodeGeneration;
+    }
+
+    public static void setAllowCodeGeneration(boolean allowCodeGeneration) {
+        PipelineRuleParser.allowCodeGeneration = allowCodeGeneration;
+    }
 
 
     public Rule parseRule(String rule, boolean silent) throws ParseException {
@@ -142,8 +160,22 @@ public class PipelineRuleParser {
         WALKER.walk(new RuleTypeChecker(parseContext), ruleDeclaration);
 
         if (parseContext.getErrors().isEmpty()) {
-            final Rule parsedRule = parseContext.getRules().get(0);
-            return parsedRule.withId(id);
+            Rule parsedRule = parseContext.getRules().get(0).withId(id);
+            if (allowCodeGeneration) {
+                final Class<? extends GeneratedRule> generatedClass = codeGenerator.generateCompiledRule(parsedRule);
+                if (generatedClass != null) {
+                    try {
+                        //noinspection unchecked
+                        final Set<Constructor> constructors = ReflectionUtils.getConstructors(generatedClass);
+                        final Constructor onlyElement = Iterables.getOnlyElement(constructors);
+                        final GeneratedRule instance = (GeneratedRule) onlyElement.newInstance(functionRegistry);
+                        return parsedRule.withGeneratedRule(instance);
+                    } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+                        log.warn("Unable to generate code for rule {}: {}", parsedRule, e);
+                    }
+                }
+            }
+            return parsedRule;
         }
         throw new ParseException(parseContext.getErrors());
     }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -85,12 +86,13 @@ import org.graylog.plugins.pipelineprocessor.parser.errors.WrongNumberOfArgs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
+
+import javax.inject.Inject;
 
 import static com.google.common.collect.ImmutableSortedSet.orderedBy;
 import static java.util.Comparator.comparingInt;
@@ -594,10 +596,10 @@ public class PipelineRuleParser {
             String type;
             // if the identifier is also a declared variable name prefer the variable
             if (isIdIsFieldAccess.peek() && !definedVars.contains(identifierName)) {
-                expr = new FieldRefExpression(ctx.getStart(), identifierName);
+                expr = new FieldRefExpression(ctx.getStart(), identifierName, parseContext.getDefinedVar(identifierName));
                 type = "FIELDREF";
             } else {
-                expr = new VarRefExpression(ctx.getStart(), identifierName);
+                expr = new VarRefExpression(ctx.getStart(), identifierName, parseContext.getDefinedVar(identifierName));
                 type = "VARREF";
             }
             log.trace("{}: ctx {} => {}", type, ctx, expr);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
@@ -97,6 +97,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.inject.Inject;
 
@@ -110,6 +111,7 @@ public class PipelineRuleParser {
     private final CodeGenerator codeGenerator;
 
     private static boolean allowCodeGeneration = false;
+    private static AtomicLong uniqueId = new AtomicLong(0);
 
     @Inject
     public PipelineRuleParser(FunctionRegistry functionRegistry, CodeGenerator codeGenerator) {
@@ -130,7 +132,7 @@ public class PipelineRuleParser {
 
 
     public Rule parseRule(String rule, boolean silent) throws ParseException {
-        return parseRule(null, rule, silent);
+        return parseRule("dummy" + uniqueId.getAndIncrement(), rule, silent);
     }
 
     public Rule parseRule(String id, String rule, boolean silent) throws ParseException {

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
@@ -106,7 +106,6 @@ public class PipelineRuleParser {
     private final FunctionRegistry functionRegistry;
     private final CodeGenerator codeGenerator;
 
-    private static boolean allowCodeGeneration = false;
     private static AtomicLong uniqueId = new AtomicLong(0);
 
     @Inject
@@ -118,20 +117,29 @@ public class PipelineRuleParser {
     private static final Logger log = LoggerFactory.getLogger(PipelineRuleParser.class);
     public static final ParseTreeWalker WALKER = ParseTreeWalker.DEFAULT;
 
-    public static boolean isAllowCodeGeneration() {
-        return allowCodeGeneration;
-    }
-
-    public static void setAllowCodeGeneration(boolean allowCodeGeneration) {
-        PipelineRuleParser.allowCodeGeneration = allowCodeGeneration;
-    }
-
-
     public Rule parseRule(String rule, boolean silent) throws ParseException {
-        return parseRule("dummy" + uniqueId.getAndIncrement(), rule, silent);
+        return parseRule(rule, silent, null);
+    }
+
+    public Rule parseRule(String rule, boolean silent, ClassLoader classLoader) throws ParseException {
+        return parseRule("dummy" + uniqueId.getAndIncrement(), rule, silent, classLoader);
     }
 
     public Rule parseRule(String id, String rule, boolean silent) throws ParseException {
+        return parseRule(id, rule, silent, null);
+    }
+
+    /**
+     * Parses the given rule source and optionally generates a Java class for it if the classloader is not null.
+     *
+     * @param id the id of the rule, necessary to generate code
+     * @param rule rule source code
+     * @param silent don't emit status messages during parsing
+     * @param ruleClassLoader the classloader to load the generated code into (can be null)
+     * @return the parse rule
+     * @throws ParseException if a one or more parse errors occur
+     */
+    public Rule parseRule(String id, String rule, boolean silent, ClassLoader ruleClassLoader) throws ParseException {
         final ParseContext parseContext = new ParseContext(silent);
         final SyntaxErrorListener errorListener = new SyntaxErrorListener(parseContext);
 
@@ -159,8 +167,8 @@ public class PipelineRuleParser {
 
         if (parseContext.getErrors().isEmpty()) {
             Rule parsedRule = parseContext.getRules().get(0).withId(id);
-            if (allowCodeGeneration) {
-                final Class<? extends GeneratedRule> generatedClass = codeGenerator.generateCompiledRule(parsedRule);
+            if (ruleClassLoader != null) {
+                final Class<? extends GeneratedRule> generatedClass = codeGenerator.generateCompiledRule(parsedRule, ruleClassLoader);
                 parsedRule = parsedRule.toBuilder().generatedRuleClass(generatedClass).build();
             }
             return parsedRule;

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
@@ -48,6 +48,7 @@ public class ConfigurationStateUpdater {
     private final MetricRegistry metricRegistry;
     private final ScheduledExecutorService scheduler;
     private final EventBus serverEventBus;
+    private final PipelineInterpreter.State.Factory stateFactory;
     /**
      * non-null if the update has successfully loaded a state
      */
@@ -60,7 +61,8 @@ public class ConfigurationStateUpdater {
                                      PipelineRuleParser pipelineRuleParser,
                                      MetricRegistry metricRegistry,
                                      @Named("daemonScheduler") ScheduledExecutorService scheduler,
-                                     EventBus serverEventBus) {
+                                     EventBus serverEventBus,
+                                     PipelineInterpreter.State.Factory stateFactory) {
         this.ruleService = ruleService;
         this.pipelineService = pipelineService;
         this.pipelineStreamConnectionsService = pipelineStreamConnectionsService;
@@ -68,6 +70,7 @@ public class ConfigurationStateUpdater {
         this.metricRegistry = metricRegistry;
         this.scheduler = scheduler;
         this.serverEventBus = serverEventBus;
+        this.stateFactory = stateFactory;
 
         // listens to cluster wide Rule, Pipeline and pipeline stream connection changes
         serverEventBus.register(this);
@@ -122,7 +125,7 @@ public class ConfigurationStateUpdater {
         }
         ImmutableSetMultimap<String, Pipeline> streamPipelineConnections = ImmutableSetMultimap.copyOf(connections);
 
-        return new PipelineInterpreter.State(currentPipelines, streamPipelineConnections);
+        return stateFactory.newState(currentPipelines, streamPipelineConnections);
     }
 
     /**

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
@@ -1,12 +1,14 @@
 package org.graylog.plugins.pipelineprocessor.processors;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+
+import com.codahale.metrics.MetricRegistry;
+
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
 import org.graylog.plugins.pipelineprocessor.db.PipelineService;
@@ -21,16 +23,17 @@ import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 
 import static com.codahale.metrics.MetricRegistry.name;
 

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -98,7 +98,6 @@ public class PipelineInterpreter implements MessageProcessor {
     public void handleStateUpdate(State newState) {
         log.debug("Updated pipeline state to {}", newState);
         state.set(newState);
-        StageIterator.clearCache();
     }
 
     /*

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -98,6 +98,7 @@ public class PipelineInterpreter implements MessageProcessor {
     public void handleStateUpdate(State newState) {
         log.debug("Updated pipeline state to {}", newState);
         state.set(newState);
+        StageIterator.clearCache();
     }
 
     /*

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/StageIterator.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/StageIterator.java
@@ -16,47 +16,79 @@
  */
 package org.graylog.plugins.pipelineprocessor.processors;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ArrayListMultimap;
+
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
 import org.graylog.plugins.pipelineprocessor.ast.Stage;
+import org.jooq.lambda.tuple.Tuple;
+import org.jooq.lambda.tuple.Tuple2;
 
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.concurrent.ExecutionException;
+
+import javax.annotation.Nonnull;
 
 public class StageIterator extends AbstractIterator<List<Stage>> {
 
     // first and last stage for the given pipelines
-    private final int[] extent = new int[]{Integer.MAX_VALUE, Integer.MIN_VALUE};
+    private int[] extent = new int[]{Integer.MAX_VALUE, Integer.MIN_VALUE};
 
     // the currentStage is always one before the next one to be returned
     private int currentStage;
 
-    private final ArrayListMultimap<Integer, Stage> stageMultimap = ArrayListMultimap.create();
+    private ArrayListMultimap<Integer, Stage> stageMultimap;
 
+    private static final LoadingCache<Set<Pipeline>, Tuple2<ArrayListMultimap<Integer, Stage>, int[]>> cache =
+            CacheBuilder.newBuilder()
+                    .build(new CacheLoader<Set<Pipeline>, Tuple2<ArrayListMultimap<Integer, Stage>, int[]>>() {
+                        @Override
+                        public Tuple2<ArrayListMultimap<Integer, Stage>, int[]> load(@Nonnull Set<Pipeline> pipelines) throws Exception {
+                            final ArrayListMultimap<Integer, Stage> stageMultimap = ArrayListMultimap.create();
+                            final int[] extent = new int[2];
+
+                            pipelines.forEach(pipeline -> {
+                                // skip pipelines without any stages, they don't contribute any rules to run
+                                final SortedSet<Stage> stages = pipeline.stages();
+                                if (stages.isEmpty()) {
+                                    return;
+                                }
+                                extent[0] = Math.min(extent[0], stages.first().stage());
+                                extent[1] = Math.max(extent[1], stages.last().stage());
+                                stages.forEach(stage -> stageMultimap.put(stage.stage(), stage));
+                            });
+                            return Tuple.tuple(stageMultimap, extent);
+                        }
+                    });
 
     public StageIterator(Set<Pipeline> pipelines) {
         if (pipelines.isEmpty()) {
             currentStage = extent[0] = extent[1] = 0;
             return;
         }
-        pipelines.forEach(pipeline -> {
-            // skip pipelines without any stages, they don't contribute any rules to run
-            final SortedSet<Stage> stages = pipeline.stages();
-            if (stages.isEmpty()) {
-                return;
-            }
-            extent[0] = Math.min(extent[0], stages.first().stage());
-            extent[1] = Math.max(extent[1], stages.last().stage());
-            stages.forEach(stage -> stageMultimap.put(stage.stage(), stage));
-        });
+
+        try {
+            final Tuple2<ArrayListMultimap<Integer, Stage>, int[]> objects = cache.get(pipelines);
+            stageMultimap = objects.v1;
+            extent = objects.v2;
+        } catch (ExecutionException e) {
+            throw new IllegalStateException(e);
+        }
 
         if (extent[0] == Integer.MIN_VALUE) {
             throw new IllegalArgumentException("First stage cannot be at " + Integer.MIN_VALUE);
         }
         // the stage before the first stage.
         currentStage = extent[0] - 1;
+    }
+
+    public static void clearCache() {
+        cache.invalidateAll();
     }
 
     @Override

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/StageIterator.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/StageIterator.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.pipelineprocessor.processors;
 
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ArrayListMultimap;
+
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
 import org.graylog.plugins.pipelineprocessor.ast.Stage;
 
@@ -27,49 +28,81 @@ import java.util.SortedSet;
 
 public class StageIterator extends AbstractIterator<List<Stage>> {
 
-    // first and last stage for the given pipelines
-    private final int[] extent = new int[]{Integer.MAX_VALUE, Integer.MIN_VALUE};
+    private final Configuration config;
 
     // the currentStage is always one before the next one to be returned
     private int currentStage;
 
-    private final ArrayListMultimap<Integer, Stage> stageMultimap = ArrayListMultimap.create();
 
+    public StageIterator(Configuration config) {
+        this.config = config;
+        currentStage = config.initialStage();
+    }
 
     public StageIterator(Set<Pipeline> pipelines) {
-        if (pipelines.isEmpty()) {
-            currentStage = extent[0] = extent[1] = 0;
-            return;
-        }
-        pipelines.forEach(pipeline -> {
-            // skip pipelines without any stages, they don't contribute any rules to run
-            final SortedSet<Stage> stages = pipeline.stages();
-            if (stages.isEmpty()) {
-                return;
-            }
-            extent[0] = Math.min(extent[0], stages.first().stage());
-            extent[1] = Math.max(extent[1], stages.last().stage());
-            stages.forEach(stage -> stageMultimap.put(stage.stage(), stage));
-        });
-
-        if (extent[0] == Integer.MIN_VALUE) {
-            throw new IllegalArgumentException("First stage cannot be at " + Integer.MIN_VALUE);
-        }
-        // the stage before the first stage.
-        currentStage = extent[0] - 1;
+        this.config = new Configuration(pipelines);
+        currentStage = config.initialStage();
     }
 
     @Override
     protected List<Stage> computeNext() {
-        if (currentStage == extent[1]) {
+        if (currentStage == config.lastStage()) {
             return endOfData();
         }
         do {
             currentStage++;
-            if (currentStage > extent[1]) {
+            if (currentStage > config.lastStage()) {
                 return endOfData();
             }
-        } while (!stageMultimap.containsKey(currentStage));
-        return stageMultimap.get(currentStage);
+        } while (!config.hasStages(currentStage));
+        return config.getStages(currentStage);
+    }
+
+    public static class Configuration {
+        // first and last stage for the given pipelines
+        private final int[] extent = new int[]{Integer.MAX_VALUE, Integer.MIN_VALUE};
+
+        private final ArrayListMultimap<Integer, Stage> stageMultimap = ArrayListMultimap.create();
+
+        private final int initialStage;
+
+        public Configuration(Set<Pipeline> pipelines) {
+            if (pipelines.isEmpty()) {
+                initialStage = extent[0] = extent[1] = 0;
+                return;
+            }
+            pipelines.forEach(pipeline -> {
+                // skip pipelines without any stages, they don't contribute any rules to run
+                final SortedSet<Stage> stages = pipeline.stages();
+                if (stages.isEmpty()) {
+                    return;
+                }
+                extent[0] = Math.min(extent[0], stages.first().stage());
+                extent[1] = Math.max(extent[1], stages.last().stage());
+                stages.forEach(stage -> stageMultimap.put(stage.stage(), stage));
+            });
+
+            if (extent[0] == Integer.MIN_VALUE) {
+                throw new IllegalArgumentException("First stage cannot be at " + Integer.MIN_VALUE);
+            }
+            // the stage before the first stage.
+            initialStage = extent[0] - 1;
+        }
+
+        public int initialStage() {
+            return initialStage;
+        }
+
+        public int lastStage() {
+            return extent[1];
+        }
+
+        public boolean hasStages(int stage) {
+            return stageMultimap.containsKey(stage);
+        }
+
+        public List<Stage> getStages(int stage) {
+            return stageMultimap.get(stage);
+        }
     }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/StageIterator.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/StageIterator.java
@@ -16,79 +16,47 @@
  */
 package org.graylog.plugins.pipelineprocessor.processors;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ArrayListMultimap;
-
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
 import org.graylog.plugins.pipelineprocessor.ast.Stage;
-import org.jooq.lambda.tuple.Tuple;
-import org.jooq.lambda.tuple.Tuple2;
 
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.concurrent.ExecutionException;
-
-import javax.annotation.Nonnull;
 
 public class StageIterator extends AbstractIterator<List<Stage>> {
 
     // first and last stage for the given pipelines
-    private int[] extent = new int[]{Integer.MAX_VALUE, Integer.MIN_VALUE};
+    private final int[] extent = new int[]{Integer.MAX_VALUE, Integer.MIN_VALUE};
 
     // the currentStage is always one before the next one to be returned
     private int currentStage;
 
-    private ArrayListMultimap<Integer, Stage> stageMultimap;
+    private final ArrayListMultimap<Integer, Stage> stageMultimap = ArrayListMultimap.create();
 
-    private static final LoadingCache<Set<Pipeline>, Tuple2<ArrayListMultimap<Integer, Stage>, int[]>> cache =
-            CacheBuilder.newBuilder()
-                    .build(new CacheLoader<Set<Pipeline>, Tuple2<ArrayListMultimap<Integer, Stage>, int[]>>() {
-                        @Override
-                        public Tuple2<ArrayListMultimap<Integer, Stage>, int[]> load(@Nonnull Set<Pipeline> pipelines) throws Exception {
-                            final ArrayListMultimap<Integer, Stage> stageMultimap = ArrayListMultimap.create();
-                            final int[] extent = new int[2];
-
-                            pipelines.forEach(pipeline -> {
-                                // skip pipelines without any stages, they don't contribute any rules to run
-                                final SortedSet<Stage> stages = pipeline.stages();
-                                if (stages.isEmpty()) {
-                                    return;
-                                }
-                                extent[0] = Math.min(extent[0], stages.first().stage());
-                                extent[1] = Math.max(extent[1], stages.last().stage());
-                                stages.forEach(stage -> stageMultimap.put(stage.stage(), stage));
-                            });
-                            return Tuple.tuple(stageMultimap, extent);
-                        }
-                    });
 
     public StageIterator(Set<Pipeline> pipelines) {
         if (pipelines.isEmpty()) {
             currentStage = extent[0] = extent[1] = 0;
             return;
         }
-
-        try {
-            final Tuple2<ArrayListMultimap<Integer, Stage>, int[]> objects = cache.get(pipelines);
-            stageMultimap = objects.v1;
-            extent = objects.v2;
-        } catch (ExecutionException e) {
-            throw new IllegalStateException(e);
-        }
+        pipelines.forEach(pipeline -> {
+            // skip pipelines without any stages, they don't contribute any rules to run
+            final SortedSet<Stage> stages = pipeline.stages();
+            if (stages.isEmpty()) {
+                return;
+            }
+            extent[0] = Math.min(extent[0], stages.first().stage());
+            extent[1] = Math.max(extent[1], stages.last().stage());
+            stages.forEach(stage -> stageMultimap.put(stage.stage(), stage));
+        });
 
         if (extent[0] == Integer.MIN_VALUE) {
             throw new IllegalArgumentException("First stage cannot be at " + Integer.MIN_VALUE);
         }
         // the stage before the first stage.
         currentStage = extent[0] - 1;
-    }
-
-    public static void clearCache() {
-        cache.invalidateAll();
     }
 
     @Override

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/BaseParserTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/BaseParserTest.java
@@ -18,12 +18,14 @@ package org.graylog.plugins.pipelineprocessor;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
+
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
 import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.statements.Statement;
+import org.graylog.plugins.pipelineprocessor.codegen.CodeGenerator;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog.plugins.pipelineprocessor.parser.PipelineRuleParser;
 import org.graylog2.plugin.Message;
@@ -31,7 +33,6 @@ import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.rules.TestName;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -40,6 +41,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.Nullable;
 
 import static com.google.common.collect.ImmutableList.of;
 
@@ -74,7 +77,7 @@ public class BaseParserTest {
 
     @Before
     public void setup() {
-        parser = new PipelineRuleParser(functionRegistry);
+        parser = new PipelineRuleParser(functionRegistry, new CodeGenerator(functionRegistry));
         // initialize before every test!
         actionsTriggered.set(false);
     }

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/codegen/Codegen.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/codegen/Codegen.java
@@ -34,6 +34,8 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class Codegen extends BaseParserTest {
     private static final Logger log = LoggerFactory.getLogger(Codegen.class);
     private static final Path PARENT = Paths.get("/Users/kroepke/projects/graylog/graylog-project-repos/graylog-plugin-pipeline-processor/plugin/");
@@ -75,6 +77,7 @@ public class Codegen extends BaseParserTest {
             //noinspection unchecked
             Class<GeneratedRule> rule$1 = (Class<GeneratedRule>) JCC.loadFromJava(ruleClassloader, "org.graylog.plugins.pipelineprocessor.$dynamic.rules.rule$1", sourceCode);
 
+            //noinspection unchecked
             final Set<Constructor> constructors = ReflectionUtils.getConstructors(rule$1, input -> input.getParameterCount() == 1);
             final Constructor onlyElement = Iterables.getOnlyElement(constructors);
             final GeneratedRule generatedRule = (GeneratedRule) onlyElement.newInstance(functionRegistry);
@@ -83,7 +86,14 @@ public class Codegen extends BaseParserTest {
             message.addField("message", "#1234");
             message.addField("something_that_doesnt_exist", "foo");
             final EvaluationContext context = new EvaluationContext(message);
-            log.info("created dynamic rule {} matches: {}", generatedRule.name(), generatedRule.when(context));
+
+            final boolean when = generatedRule.when(context);
+            if (when) {
+                generatedRule.then(context);
+            }
+            log.info("created dynamic rule {} matches: {}", generatedRule.name(), when);
+
+            assertThat(context.currentMessage().hasField("some_identifier")).isTrue();
 
         } catch (InvocationTargetException | ClassNotFoundException | InstantiationException | IllegalAccessException e) {
             log.error("Cannot load dynamically created class!", e);

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/codegen/Codegen.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/codegen/Codegen.java
@@ -20,6 +20,7 @@ import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.reflections.ReflectionUtils;
 import org.slf4j.Logger;
@@ -36,6 +37,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Ignore("Replaced by CodegenPipelineRuleParserTest")
 public class Codegen extends BaseParserTest {
     private static final Logger log = LoggerFactory.getLogger(Codegen.class);
     private static final Path PARENT = Paths.get("/Users/kroepke/projects/graylog/graylog-project-repos/graylog-plugin-pipeline-processor/plugin/");

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/codegen/Codegen.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/codegen/Codegen.java
@@ -1,0 +1,45 @@
+package org.graylog.plugins.pipelineprocessor.codegen;
+
+import com.google.common.collect.Maps;
+
+import org.graylog.plugins.pipelineprocessor.BaseParserTest;
+import org.graylog.plugins.pipelineprocessor.ast.Rule;
+import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
+import org.graylog.plugins.pipelineprocessor.functions.messages.HasField;
+import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
+import org.graylog.plugins.pipelineprocessor.functions.messages.SetFields;
+import org.graylog.plugins.pipelineprocessor.functions.strings.RegexMatch;
+import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class Codegen extends BaseParserTest {
+    private static final Logger log = LoggerFactory.getLogger(Codegen.class);
+
+    @BeforeClass
+    public static void registerFunctions() {
+
+        Map<String, Function<?>> functions = Maps.newHashMap();
+
+        functions.put(StringConversion.NAME, new StringConversion());
+        functions.put(SetField.NAME, new SetField());
+        functions.put(SetFields.NAME, new SetFields());
+        functions.put(HasField.NAME, new HasField());
+        functions.put(RegexMatch.NAME, new RegexMatch());
+
+        functionRegistry = new FunctionRegistry(functions);
+    }
+
+    @Test
+    public void runCodegen() {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+
+        log.info("Code:\n{}", CodeGenerator.codeForRule(rule));
+    }
+
+}

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/codegen/Codegen.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/codegen/Codegen.java
@@ -62,9 +62,9 @@ public class Codegen extends BaseParserTest {
 
     @Test
     public void runCodegen() throws IOException {
-        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Rule rule = parser.parseRule(ruleForTest(), true).withId("1");
 
-        final String sourceCode = CodeGenerator.codeForRule(rule);
+        final String sourceCode = CodeGenerator.sourceCodeForRule(rule);
         Files.write(sourceCode,
                 OUTFILE.toFile(),
                 StandardCharsets.UTF_8);

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/CodegenPipelineRuleParserTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/CodegenPipelineRuleParserTest.java
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.parser;
+
+public class CodegenPipelineRuleParserTest extends PipelineRuleParserTest {
+
+    // runs the same tests as in PipelineRuleParserTest but with dynamic code generation turned on.
+    public CodegenPipelineRuleParserTest() {
+        PipelineRuleParser.setAllowCodeGeneration(true);
+    }
+}

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/CodegenPipelineRuleParserTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/CodegenPipelineRuleParserTest.java
@@ -20,6 +20,6 @@ public class CodegenPipelineRuleParserTest extends PipelineRuleParserTest {
 
     // runs the same tests as in PipelineRuleParserTest but with dynamic code generation turned on.
     public CodegenPipelineRuleParserTest() {
-        PipelineRuleParser.setAllowCodeGeneration(true);
+        classLoader = new ClassLoader(){};
     }
 }

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
@@ -73,215 +73,22 @@ public class PipelineRuleParserTest extends BaseParserTest {
     @BeforeClass
     public static void registerFunctions() {
         final Map<String, Function<?>> functions = commonFunctions();
-        functions.put("nein", new AbstractFunction<Boolean>() {
-            @Override
-            public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
-                return false;
-            }
-
-            @Override
-            public FunctionDescriptor<Boolean> descriptor() {
-                return FunctionDescriptor.<Boolean>builder()
-                        .name("nein")
-                        .returnType(Boolean.class)
-                        .params(of())
-                        .build();
-            }
-        });
-        functions.put("doch", new AbstractFunction<Boolean>() {
-            @Override
-            public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
-                return true;
-            }
-
-            @Override
-            public FunctionDescriptor<Boolean> descriptor() {
-                return FunctionDescriptor.<Boolean>builder()
-                        .name("doch")
-                        .returnType(Boolean.class)
-                        .params(of())
-                        .build();
-            }
-        });
-        functions.put("double_valued_func", new AbstractFunction<Double>() {
-            @Override
-            public Double evaluate(FunctionArgs args, EvaluationContext context) {
-                return 0d;
-            }
-
-            @Override
-            public FunctionDescriptor<Double> descriptor() {
-                return FunctionDescriptor.<Double>builder()
-                        .name("double_valued_func")
-                        .returnType(Double.class)
-                        .params(of())
-                        .build();
-            }
-        });
-        functions.put("one_arg", new AbstractFunction<String>() {
-
-            private final ParameterDescriptor<String, String> one = ParameterDescriptor.string("one").build();
-
-            @Override
-            public String evaluate(FunctionArgs args, EvaluationContext context) {
-                return one.optional(args, context).orElse("");
-            }
-
-            @Override
-            public FunctionDescriptor<String> descriptor() {
-                return FunctionDescriptor.<String>builder()
-                        .name("one_arg")
-                        .returnType(String.class)
-                        .params(of(one))
-                        .build();
-            }
-        });
-        functions.put("concat", new AbstractFunction<String>() {
-
-            private final ParameterDescriptor<Object, Object> three = ParameterDescriptor.object("three").build();
-            private final ParameterDescriptor<Object, Object> two = ParameterDescriptor.object("two").build();
-            private final ParameterDescriptor<String, String> one = ParameterDescriptor.string("one").build();
-
-            @Override
-            public String evaluate(FunctionArgs args, EvaluationContext context) {
-                final Object one = this.one.optional(args, context).orElse("");
-                final Object two = this.two.optional(args, context).orElse("");
-                final Object three = this.three.optional(args, context).orElse("");
-                return one.toString() + two.toString() + three.toString();
-            }
-
-            @Override
-            public FunctionDescriptor<String> descriptor() {
-                return FunctionDescriptor.<String>builder()
-                        .name("concat")
-                        .returnType(String.class)
-                        .params(of(
-                                one,
-                                two,
-                                three
-                        ))
-                        .build();
-            }
-        });
-        functions.put("trigger_test", new AbstractFunction<Void>() {
-            @Override
-            public Void evaluate(FunctionArgs args, EvaluationContext context) {
-                actionsTriggered.set(true);
-                return null;
-            }
-
-            @Override
-            public FunctionDescriptor<Void> descriptor() {
-                return FunctionDescriptor.<Void>builder()
-                        .name("trigger_test")
-                        .returnType(Void.class)
-                        .params(of())
-                        .build();
-            }
-        });
-        functions.put("optional", new AbstractFunction<Boolean>() {
-            @Override
-            public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
-                return true;
-            }
-
-            @Override
-            public FunctionDescriptor<Boolean> descriptor() {
-                return FunctionDescriptor.<Boolean>builder()
-                        .name("optional")
-                        .returnType(Boolean.class)
-                        .params(of(
-                                ParameterDescriptor.bool("a").build(),
-                                ParameterDescriptor.string("b").build(),
-                                ParameterDescriptor.floating("c").optional().build(),
-                                ParameterDescriptor.integer("d").build()
-                        ))
-                        .build();
-            }
-        });
-        functions.put("customObject", new AbstractFunction<CustomObject>() {
-
-            private final ParameterDescriptor<String, String> aDefault = ParameterDescriptor.string("default").build();
-
-            @Override
-            public CustomObject evaluate(FunctionArgs args, EvaluationContext context) {
-                return new CustomObject(aDefault.optional(args, context).orElse(""));
-            }
-
-            @Override
-            public FunctionDescriptor<CustomObject> descriptor() {
-                return FunctionDescriptor.<CustomObject>builder()
-                        .name("customObject")
-                        .returnType(CustomObject.class)
-                        .params(of(aDefault))
-                        .build();
-            }
-        });
-        functions.put("keys", new AbstractFunction<List>() {
-
-            private final ParameterDescriptor<Map, Map> map = ParameterDescriptor.type("map", Map.class).build();
-
-            @Override
-            public List evaluate(FunctionArgs args, EvaluationContext context) {
-                final Optional<Map> map = this.map.optional(args, context);
-                return Lists.newArrayList(map.orElse(Collections.emptyMap()).keySet());
-            }
-
-            @Override
-            public FunctionDescriptor<List> descriptor() {
-                return FunctionDescriptor.<List>builder()
-                        .name("keys")
-                        .returnType(List.class)
-                        .params(of(map))
-                        .build();
-            }
-        });
-        functions.put("sort", new AbstractFunction<Collection>() {
-
-            private final ParameterDescriptor<Collection, Collection> collection = ParameterDescriptor.type("collection",
-                                                                                                            Collection.class).build();
-
-            @Override
-            public Collection evaluate(FunctionArgs args, EvaluationContext context) {
-                final Collection collection = this.collection.optional(args, context).orElse(Collections.emptyList());
-                return Ordering.natural().sortedCopy(collection);
-            }
-
-            @Override
-            public FunctionDescriptor<Collection> descriptor() {
-                return FunctionDescriptor.<Collection>builder()
-                        .name("sort")
-                        .returnType(Collection.class)
-                        .params(of(collection))
-                        .build();
-            }
-        });
+        functions.put("nein", new NeinFunction());
+        functions.put("doch", new DochFunction());
+        functions.put("double_valued_func", new DoubleValuedFunction());
+        functions.put("one_arg", new OneArgFunction());
+        functions.put("concat", new ConcatFunction());
+        functions.put("trigger_test", new TriggerTestFunction());
+        functions.put("optional", new OptionalFunction());
+        functions.put("customObject", new CustomObjectFunction());
+        functions.put("keys", new KeysFunction());
+        functions.put("sort", new SortFunction());
         functions.put(LongConversion.NAME, new LongConversion());
         functions.put(StringConversion.NAME, new StringConversion());
         functions.put(SetField.NAME, new SetField());
         functions.put(HasField.NAME, new HasField());
         functions.put(RegexMatch.NAME, new RegexMatch());
-        functions.put("now_in_tz", new TimezoneAwareFunction() {
-            @Override
-            protected DateTime evaluate(FunctionArgs args, EvaluationContext context, DateTimeZone timezone) {
-                return DateTime.now(timezone);
-            }
-
-            @Override
-            protected String description() {
-                return "Now in the given timezone";
-            }
-
-            @Override
-            protected String getName() {
-                return "now_in_tz";
-            }
-
-            @Override
-            protected ImmutableList<ParameterDescriptor> params() {
-                return ImmutableList.of();
-            }
-        });
+        functions.put("now_in_tz", new NowInTimezoneFunction());
         functionRegistry = new FunctionRegistry(functions);
     }
 
@@ -544,6 +351,221 @@ public class PipelineRuleParserTest extends BaseParserTest {
 
         public String getId() {
             return id;
+        }
+    }
+
+    public static class NeinFunction extends AbstractFunction<Boolean> {
+        @Override
+        public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+            return false;
+        }
+
+        @Override
+        public FunctionDescriptor<Boolean> descriptor() {
+            return FunctionDescriptor.<Boolean>builder()
+                    .name("nein")
+                    .returnType(Boolean.class)
+                    .params(of())
+                    .build();
+        }
+    }
+
+    public static class DochFunction extends AbstractFunction<Boolean> {
+        @Override
+        public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+            return true;
+        }
+
+        @Override
+        public FunctionDescriptor<Boolean> descriptor() {
+            return FunctionDescriptor.<Boolean>builder()
+                    .name("doch")
+                    .returnType(Boolean.class)
+                    .params(of())
+                    .build();
+        }
+    }
+
+    public static class DoubleValuedFunction extends AbstractFunction<Double> {
+        @Override
+        public Double evaluate(FunctionArgs args, EvaluationContext context) {
+            return 0d;
+        }
+
+        @Override
+        public FunctionDescriptor<Double> descriptor() {
+            return FunctionDescriptor.<Double>builder()
+                    .name("double_valued_func")
+                    .returnType(Double.class)
+                    .params(of())
+                    .build();
+        }
+    }
+
+    public static class OneArgFunction extends AbstractFunction<String> {
+
+        private final ParameterDescriptor<String, String> one = ParameterDescriptor.string("one").build();
+
+        @Override
+        public String evaluate(FunctionArgs args, EvaluationContext context) {
+            return one.optional(args, context).orElse("");
+        }
+
+        @Override
+        public FunctionDescriptor<String> descriptor() {
+            return FunctionDescriptor.<String>builder()
+                    .name("one_arg")
+                    .returnType(String.class)
+                    .params(of(one))
+                    .build();
+        }
+    }
+
+    public static class ConcatFunction extends AbstractFunction<String> {
+
+        private final ParameterDescriptor<Object, Object> three = ParameterDescriptor.object("three").build();
+        private final ParameterDescriptor<Object, Object> two = ParameterDescriptor.object("two").build();
+        private final ParameterDescriptor<String, String> one = ParameterDescriptor.string("one").build();
+
+        @Override
+        public String evaluate(FunctionArgs args, EvaluationContext context) {
+            final Object one = this.one.optional(args, context).orElse("");
+            final Object two = this.two.optional(args, context).orElse("");
+            final Object three = this.three.optional(args, context).orElse("");
+            return one.toString() + two.toString() + three.toString();
+        }
+
+        @Override
+        public FunctionDescriptor<String> descriptor() {
+            return FunctionDescriptor.<String>builder()
+                    .name("concat")
+                    .returnType(String.class)
+                    .params(of(
+                            one,
+                            two,
+                            three
+                    ))
+                    .build();
+        }
+    }
+
+    public static class TriggerTestFunction extends AbstractFunction<Void> {
+        @Override
+        public Void evaluate(FunctionArgs args, EvaluationContext context) {
+            actionsTriggered.set(true);
+            return null;
+        }
+
+        @Override
+        public FunctionDescriptor<Void> descriptor() {
+            return FunctionDescriptor.<Void>builder()
+                    .name("trigger_test")
+                    .returnType(Void.class)
+                    .params(of())
+                    .build();
+        }
+    }
+
+    public static class OptionalFunction extends AbstractFunction<Boolean> {
+        @Override
+        public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+            return true;
+        }
+
+        @Override
+        public FunctionDescriptor<Boolean> descriptor() {
+            return FunctionDescriptor.<Boolean>builder()
+                    .name("optional")
+                    .returnType(Boolean.class)
+                    .params(of(
+                            ParameterDescriptor.bool("a").build(),
+                            ParameterDescriptor.string("b").build(),
+                            ParameterDescriptor.floating("c").optional().build(),
+                            ParameterDescriptor.integer("d").build()
+                    ))
+                    .build();
+        }
+    }
+
+    public static class CustomObjectFunction extends AbstractFunction<CustomObject> {
+
+        private final ParameterDescriptor<String, String> aDefault = ParameterDescriptor.string("default").build();
+
+        @Override
+        public CustomObject evaluate(FunctionArgs args, EvaluationContext context) {
+            return new CustomObject(aDefault.optional(args, context).orElse(""));
+        }
+
+        @Override
+        public FunctionDescriptor<CustomObject> descriptor() {
+            return FunctionDescriptor.<CustomObject>builder()
+                    .name("customObject")
+                    .returnType(CustomObject.class)
+                    .params(of(aDefault))
+                    .build();
+        }
+    }
+
+    public static class KeysFunction extends AbstractFunction<List> {
+
+        private final ParameterDescriptor<Map, Map> map = ParameterDescriptor.type("map", Map.class).build();
+
+        @Override
+        public List evaluate(FunctionArgs args, EvaluationContext context) {
+            final Optional<Map> map = this.map.optional(args, context);
+            return Lists.newArrayList(map.orElse(Collections.emptyMap()).keySet());
+        }
+
+        @Override
+        public FunctionDescriptor<List> descriptor() {
+            return FunctionDescriptor.<List>builder()
+                    .name("keys")
+                    .returnType(List.class)
+                    .params(of(map))
+                    .build();
+        }
+    }
+
+    public static class SortFunction extends AbstractFunction<Collection> {
+
+        private final ParameterDescriptor<Collection, Collection> collection = ParameterDescriptor.type("collection",
+                                                                                                        Collection.class).build();
+
+        @Override
+        public Collection evaluate(FunctionArgs args, EvaluationContext context) {
+            final Collection collection = this.collection.optional(args, context).orElse(Collections.emptyList());
+            return Ordering.natural().sortedCopy(collection);
+        }
+
+        @Override
+        public FunctionDescriptor<Collection> descriptor() {
+            return FunctionDescriptor.<Collection>builder()
+                    .name("sort")
+                    .returnType(Collection.class)
+                    .params(of(collection))
+                    .build();
+        }
+    }
+
+    public static class NowInTimezoneFunction extends TimezoneAwareFunction {
+        @Override
+        protected DateTime evaluate(FunctionArgs args, EvaluationContext context, DateTimeZone timezone) {
+            return DateTime.now(timezone);
+        }
+
+        @Override
+        protected String description() {
+            return "Now in the given timezone";
+        }
+
+        @Override
+        protected String getName() {
+            return "now_in_tz";
+        }
+
+        @Override
+        protected ImmutableList<ParameterDescriptor> params() {
+            return ImmutableList.of();
         }
     }
 }

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
+
 import org.graylog.plugins.pipelineprocessor.BaseParserTest;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
@@ -70,6 +70,8 @@ import static org.junit.Assert.fail;
 
 public class PipelineRuleParserTest extends BaseParserTest {
 
+    protected static ClassLoader classLoader;
+
     @BeforeClass
     public static void registerFunctions() {
         final Map<String, Function<?>> functions = commonFunctions();
@@ -97,16 +99,20 @@ public class PipelineRuleParserTest extends BaseParserTest {
         parser = null;
     }
 
+    private Rule parseRuleWithOptionalCodegen() {
+        return parser.parseRule(ruleForTest(), false, classLoader);
+    }
+
     @Test
     public void basicRule() throws Exception {
-        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final Rule rule = parseRuleWithOptionalCodegen();
         Assert.assertNotNull("rule should be successfully parsed", rule);
     }
 
     @Test
     public void undeclaredIdentifier() throws Exception {
         try {
-            parser.parseRule(ruleForTest(), false);
+            parseRuleWithOptionalCodegen();
             fail("should throw error: undeclared variable x");
         } catch (ParseException e) {
             assertEquals(2,
@@ -119,7 +125,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     @Test
     public void declaredFunction() throws Exception {
         try {
-            parser.parseRule(ruleForTest(), false);
+            parseRuleWithOptionalCodegen();
         } catch (ParseException e) {
             fail("Should not fail to resolve function 'false'");
         }
@@ -128,7 +134,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     @Test
     public void undeclaredFunction() throws Exception {
         try {
-            parser.parseRule(ruleForTest(), false);
+            parseRuleWithOptionalCodegen();
             fail("should throw error: undeclared function 'unknown'");
         } catch (ParseException e) {
             assertTrue("Should find error UndeclaredFunction",
@@ -139,7 +145,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     @Test
     public void singleArgFunction() throws Exception {
         try {
-            final Rule rule = parser.parseRule(ruleForTest(), false);
+            final Rule rule = parseRuleWithOptionalCodegen();
             final Message message = evaluateRule(rule);
 
             assertNotNull(message);
@@ -152,7 +158,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     @Test
     public void positionalArguments() throws Exception {
         try {
-            final Rule rule = parser.parseRule(ruleForTest(), false);
+            final Rule rule = parseRuleWithOptionalCodegen();
             evaluateRule(rule);
 
             assertTrue(actionsTriggered.get());
@@ -164,7 +170,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     @Test
     public void inferVariableType() throws Exception {
         try {
-            final Rule rule = parser.parseRule(ruleForTest(), false);
+            final Rule rule = parseRuleWithOptionalCodegen();
 
             evaluateRule(rule);
         } catch (ParseException e) {
@@ -175,7 +181,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     @Test
     public void invalidArgType() throws Exception {
         try {
-            parser.parseRule(ruleForTest(), false);
+            parseRuleWithOptionalCodegen();
         } catch (ParseException e) {
             assertEquals(2, e.getErrors().size());
             assertTrue("Should only find IncompatibleArgumentType errors",
@@ -186,7 +192,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     @Test
     public void booleanValuedFunctionAsCondition() throws Exception {
         try {
-            final Rule rule = parser.parseRule(ruleForTest(), false);
+            final Rule rule = parseRuleWithOptionalCodegen();
 
             evaluateRule(rule);
             assertTrue("actions should have triggered", actionsTriggered.get());
@@ -197,7 +203,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
 
     @Test
     public void messageRef() throws Exception {
-        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final Rule rule = parseRuleWithOptionalCodegen();
         Message message = new Message("hello test", "source", DateTime.now());
         message.addField("responseCode", 500);
         final Message processedMsg = evaluateRule(rule, message);
@@ -208,7 +214,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
 
     @Test
     public void messageRefQuotedField() throws Exception {
-        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final Rule rule = parseRuleWithOptionalCodegen();
         Message message = new Message("hello test", "source", DateTime.now());
         message.addField("@specialfieldname", "string");
         evaluateRule(rule, message);
@@ -218,7 +224,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
 
     @Test
     public void optionalArguments() throws Exception {
-        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final Rule rule = parseRuleWithOptionalCodegen();
 
         Message message = new Message("hello test", "source", DateTime.now());
         evaluateRule(rule, message);
@@ -228,7 +234,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     @Test
     public void optionalParamsMustBeNamed() throws Exception {
         try {
-            parser.parseRule(ruleForTest(), false);
+            parseRuleWithOptionalCodegen();
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().stream().count());
             assertTrue(e.getErrors().stream().allMatch(error -> error instanceof OptionalParametersMustBeNamed));
@@ -238,7 +244,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
 
     @Test
     public void mapArrayLiteral() {
-        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final Rule rule = parseRuleWithOptionalCodegen();
         Message message = new Message("hello test", "source", DateTime.now());
         evaluateRule(rule, message);
         assertTrue(actionsTriggered.get());
@@ -247,7 +253,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     @Test
     public void typedFieldAccess() throws Exception {
         try {
-            final Rule rule = parser.parseRule(ruleForTest(), false);
+            final Rule rule = parseRuleWithOptionalCodegen();
             evaluateRule(rule, new Message("hallo", "test", DateTime.now()));
             assertTrue("condition should be true", actionsTriggered.get());
         } catch (ParseException e) {
@@ -277,7 +283,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
 
     @Test
     public void indexedAccess() {
-        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final Rule rule = parseRuleWithOptionalCodegen();
 
         evaluateRule(rule, new Message("hallo", "test", DateTime.now()));
         assertTrue("condition should be true", actionsTriggered.get());
@@ -286,7 +292,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     @Test
     public void indexedAccessWrongType() {
         try {
-            parser.parseRule(ruleForTest(), false);
+            parseRuleWithOptionalCodegen();
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
             assertEquals(NonIndexableType.class, Iterables.getOnlyElement(e.getErrors()).getClass());
@@ -296,7 +302,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     @Test
     public void indexedAccessWrongIndexType() {
         try {
-            parser.parseRule(ruleForTest(), false);
+            parseRuleWithOptionalCodegen();
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
             assertEquals(IncompatibleIndexType.class, Iterables.getOnlyElement(e.getErrors()).getClass());
@@ -306,7 +312,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     @Test
     public void invalidArgumentValue() {
         try {
-            parser.parseRule(ruleForTest(), false);
+            parseRuleWithOptionalCodegen();
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
             final ParseError parseError = Iterables.getOnlyElement(e.getErrors());
@@ -317,7 +323,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
 
     @Test
     public void arithmetic() {
-        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final Rule rule = parseRuleWithOptionalCodegen();
         evaluateRule(rule);
 
         assertTrue(actionsTriggered.get());
@@ -326,7 +332,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     @Test
     public void mismatchedNumericTypes() {
         try {
-            parser.parseRule(ruleForTest(), false);
+            parseRuleWithOptionalCodegen();
             fail("Should have thrown parse exception");
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PrecedenceTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PrecedenceTest.java
@@ -26,6 +26,7 @@ import org.graylog.plugins.pipelineprocessor.ast.expressions.LogicalExpression;
 import org.graylog.plugins.pipelineprocessor.ast.expressions.NotExpression;
 import org.graylog.plugins.pipelineprocessor.ast.expressions.OrExpression;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
+import org.graylog.plugins.pipelineprocessor.codegen.CodeGenerator;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
@@ -126,7 +127,7 @@ public class PrecedenceTest extends BaseParserTest {
     }
 
     private static Rule parseRule(String rule) {
-        final PipelineRuleParser parser = new PipelineRuleParser(functionRegistry);
+        final PipelineRuleParser parser = new PipelineRuleParser(functionRegistry, new CodeGenerator(functionRegistry));
         return parser.parseRule(rule, true);
     }
 }

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PrecedenceTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PrecedenceTest.java
@@ -127,7 +127,7 @@ public class PrecedenceTest extends BaseParserTest {
     }
 
     private static Rule parseRule(String rule) {
-        final PipelineRuleParser parser = new PipelineRuleParser(functionRegistry, new CodeGenerator(functionRegistry));
+        final PipelineRuleParser parser = new PipelineRuleParser(functionRegistry, new CodeGenerator());
         return parser.parseRule(rule, true);
     }
 }

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -116,7 +116,8 @@ public class PipelineInterpreterTest {
                 functionRegistry,
                 Executors.newScheduledThreadPool(1),
                 mock(EventBus.class),
-                (currentPipelines, streamPipelineConnections) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, new MetricRegistry(), 1, true));
+                (currentPipelines, streamPipelineConnections, classLoader) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, null, new MetricRegistry(), 1, true),
+                false);
         final PipelineInterpreter interpreter = new PipelineInterpreter(
                 mock(Journal.class),
                 new MetricRegistry(),
@@ -175,7 +176,8 @@ public class PipelineInterpreterTest {
                 metricRegistry,
                 functionRegistry,
                 Executors.newScheduledThreadPool(1),
-                mock(EventBus.class), (currentPipelines, streamPipelineConnections) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, new MetricRegistry(), 1, true));
+                mock(EventBus.class), (currentPipelines, streamPipelineConnections, commonClassLoader) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, null, new MetricRegistry(), 1, true),
+                false);
         final PipelineInterpreter interpreter = new PipelineInterpreter(
                 mock(Journal.class),
                 metricRegistry,

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -108,12 +108,13 @@ public class PipelineInterpreterTest {
         final PipelineRuleParser parser = setupParser(functions);
 
         final ConfigurationStateUpdater stateUpdater = new ConfigurationStateUpdater(ruleService,
-                                                                                     pipelineService,
-                                                                                     pipelineStreamConnectionsService,
-                                                                                     parser,
-                                                                                     new MetricRegistry(),
-                                                                                     Executors.newScheduledThreadPool(1),
-                                                                                     mock(EventBus.class));
+                pipelineService,
+                pipelineStreamConnectionsService,
+                parser,
+                new MetricRegistry(),
+                Executors.newScheduledThreadPool(1),
+                mock(EventBus.class),
+                (currentPipelines, streamPipelineConnections) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, new MetricRegistry(), 1, true));
         final PipelineInterpreter interpreter = new PipelineInterpreter(
                 mock(Journal.class),
                 new MetricRegistry(),
@@ -165,12 +166,12 @@ public class PipelineInterpreterTest {
 
         final MetricRegistry metricRegistry = new MetricRegistry();
         final ConfigurationStateUpdater stateUpdater = new ConfigurationStateUpdater(ruleService,
-                                                                                     pipelineService,
-                                                                                     pipelineStreamConnectionsService,
-                                                                                     parser,
-                                                                                     metricRegistry,
-                                                                                     Executors.newScheduledThreadPool(1),
-                                                                                     mock(EventBus.class));
+                pipelineService,
+                pipelineStreamConnectionsService,
+                parser,
+                metricRegistry,
+                Executors.newScheduledThreadPool(1),
+                mock(EventBus.class), (currentPipelines, streamPipelineConnections) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, new MetricRegistry(), 1, true));
         final PipelineInterpreter interpreter = new PipelineInterpreter(
                 mock(Journal.class),
                 metricRegistry,

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -16,14 +16,17 @@
  */
 package org.graylog.plugins.pipelineprocessor.processors;
 
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
+import org.graylog.plugins.pipelineprocessor.codegen.CodeGenerator;
 import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
 import org.graylog.plugins.pipelineprocessor.db.PipelineService;
 import org.graylog.plugins.pipelineprocessor.db.PipelineStreamConnectionsService;
@@ -221,7 +224,7 @@ public class PipelineInterpreterTest {
 
     private PipelineRuleParser setupParser(Map<String, Function<?>> functions) {
         final FunctionRegistry functionRegistry = new FunctionRegistry(functions);
-        return new PipelineRuleParser(functionRegistry);
+        return new PipelineRuleParser(functionRegistry, new CodeGenerator(functionRegistry));
     }
 
     private Message messageInDefaultStream(String message, String source) {

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -225,7 +225,7 @@ public class PipelineInterpreterTest {
 
     private PipelineRuleParser setupParser(Map<String, Function<?>> functions) {
         final FunctionRegistry functionRegistry = new FunctionRegistry(functions);
-        return new PipelineRuleParser(functionRegistry, new CodeGenerator(functionRegistry));
+        return new PipelineRuleParser(functionRegistry, new CodeGenerator());
     }
 
     private Message messageInDefaultStream(String message, String source) {

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/codegen/runCodegen.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/codegen/runCodegen.txt
@@ -1,7 +1,7 @@
 rule "grok jenkins extraction"
 when
     to_string($message.source) == "jenkins.torch.sh" &&
-    regex("#\\d+", to_string($message.message)).matches == true || !has_field("something_that_doesnt_exist")
+    (regex("#\\d+", to_string($message.message)).matches == true || !has_field("something_that_doesnt_exist"))
 then
     let number = 1;
     let string = "sadfasdf";

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/codegen/runCodegen.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/codegen/runCodegen.txt
@@ -6,6 +6,6 @@ then
     let number = 1;
     let string = "sadfasdf";
     let fields = {some_identifier: 1, `something with spaces`: "some expression"};
-    let ary = [1,3,4,5,"object"];
+    let ary = [1,3,4,5,"object", string];
     set_fields(fields);
 end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/codegen/runCodegen.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/codegen/runCodegen.txt
@@ -1,0 +1,11 @@
+rule "grok jenkins extraction"
+when
+    to_string($message.source) == "jenkins.torch.sh" &&
+    regex("#\\d+", to_string($message.message)).matches == true || !has_field("something_that_doesnt_exist")
+then
+    let number = 1;
+    let string = "sadfasdf";
+    let fields = {some_identifier: 1, `something with spaces`: "some expression"};
+    let ary = [1,3,4,5,"object"];
+    set_fields(fields);
+end


### PR DESCRIPTION
This change primarily introduces two things:

 - add option to cache the bulk of the data necessary to provide `StageIterator` instances, the most expensive infrastructure part the interpreter has to calculate
 - optionally generate Java source code (and runtime compiled classes) for each individual rule which is invoked instead of interpreting the AST if present

The stage iterator caching is almost trivial, because the set of pipelines remains static during any run and directly influences the set of stages to run. This can be cached naturally and since the cache lives with the interpreter state, it is automatically purged whenever the configuration changes. There is a configuration option to turn this caching off, which is primarily intended for benchmarking purposes.

The code generator is also gated with a configuration option and also turned on by default.
It consists of three different parts:

 - An AST visitor which constructs the source code for a single class that implements one single rule
 - An interface to the `tools.jar` compiler interface of the JDK (this requires a JDK, a JRE is not enough to run this anymore)
 - Hooks in the interpreter to invoke the `when`/`then` methods if the generated class is present.

The external interfaces have not changed.

Connected to #114
Fix #114 