### PR TITLE
Turn off code generation if no compiler available

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/codegen/CodeGenerator.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/codegen/CodeGenerator.java
@@ -95,7 +95,7 @@ public class CodeGenerator {
             return (Class<GeneratedRule>) CompilerUtils.CACHED_COMPILER.loadFromJava(ruleClassloader, "org.graylog.plugins.pipelineprocessor.$dynamic.rules.rule$" + rule.id() , sourceCode);
         } catch (ClassNotFoundException e) {
             log.error("Unable to compile code\n{}", sourceCode);
-            throw new RuntimeException(e);
+            return null;
         }
 
     }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
@@ -85,6 +85,7 @@ import org.graylog.plugins.pipelineprocessor.parser.errors.SyntaxError;
 import org.graylog.plugins.pipelineprocessor.parser.errors.UndeclaredFunction;
 import org.graylog.plugins.pipelineprocessor.parser.errors.UndeclaredVariable;
 import org.graylog.plugins.pipelineprocessor.parser.errors.WrongNumberOfArgs;
+import org.graylog.plugins.pipelineprocessor.processors.ConfigurationStateUpdater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -167,9 +168,11 @@ public class PipelineRuleParser {
 
         if (parseContext.getErrors().isEmpty()) {
             Rule parsedRule = parseContext.getRules().get(0).withId(id);
-            if (ruleClassLoader != null) {
+            if (ruleClassLoader != null || ConfigurationStateUpdater.isAllowCodeGeneration()) {
                 final Class<? extends GeneratedRule> generatedClass = codeGenerator.generateCompiledRule(parsedRule, ruleClassLoader);
-                parsedRule = parsedRule.toBuilder().generatedRuleClass(generatedClass).build();
+                if (generatedClass != null) {
+                    parsedRule = parsedRule.toBuilder().generatedRuleClass(generatedClass).build();
+                }
             }
             return parsedRule;
         }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
@@ -35,6 +35,7 @@ import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import javax.tools.ToolProvider;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
@@ -88,6 +89,12 @@ public class ConfigurationStateUpdater {
     }
 
     public static void setAllowCodeGeneration(Boolean allowCodeGeneration) {
+        if (ToolProvider.getSystemJavaCompiler() == null) {
+            log.warn("Your Java runtime does not have a compiler available, turning off dynamic " +
+                    "code generation. Please consider running Graylog in a JDK, not a JRE, to " +
+                    "avoid a performance penalty in pipeline processing.");
+            allowCodeGeneration = false;
+        }
         ConfigurationStateUpdater.allowCodeGeneration = allowCodeGeneration;
     }
 

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
@@ -89,7 +89,7 @@ public class ConfigurationStateUpdater {
     }
 
     public static void setAllowCodeGeneration(Boolean allowCodeGeneration) {
-        if (ToolProvider.getSystemJavaCompiler() == null) {
+        if (allowCodeGeneration && ToolProvider.getSystemJavaCompiler() == null) {
             log.warn("Your Java runtime does not have a compiler available, turning off dynamic " +
                     "code generation. Please consider running Graylog in a JDK, not a JRE, to " +
                     "avoid a performance penalty in pipeline processing.");


### PR DESCRIPTION
this typically happens in a JRE, which has the ToolProvider, but not the tools.jar.
we ask to run on a JDK instead

fail more gracefully on compilation errors

fixes #132