### PR TITLE
[WIP] String concat/format

### DIFF
--- a/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/StringFormat.java
+++ b/benchmarks/src/main/java/org/graylog/benchmarks/pipeline/StringFormat.java
@@ -1,0 +1,105 @@
+package org.graylog.benchmarks.pipeline;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.floreysoft.jmte.Engine;
+import com.floreysoft.jmte.template.Template;
+
+import org.apache.commons.lang3.text.StrSubstitutor;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Benchmarks the concatenation of multiple constant strings and some (low) number of objects which need to be converted to strings.
+ * Essentially a format string like: "Some wonderful {} has {} fields, and it contains {} different values." with three parameters, "message", 11L, 4.5d
+ */
+public class StringFormat {
+
+    @State(Scope.Benchmark)
+    public static class BState {
+        public final Object objects[] = {
+                "message", 11L, 4.5d
+        };
+        public final String constantStringParts[] = {
+                "Some wonderful ", " has ", " fields, and it contains ", " different values."
+        };
+
+        public final Map<String, Object> namedArgs = ImmutableMap.<String, Object>builder()
+                .put("string", "message")
+                .put("long", 11L)
+                .put("double", 4.5d)
+                .build();
+
+        public final Engine compilingEngine = Engine.createCompilingEngine();
+
+        public final Template jmteTemplate = compilingEngine.getTemplate("Some wonderful ${string} has ${long} fields, and it contains ${double} different values.");
+
+    }
+
+    @Benchmark
+    public void plusOperator(Blackhole bh, BState state) {
+        bh.consume(
+                state.constantStringParts[0] + String.valueOf(state.objects[0]) +
+                state.constantStringParts[1] + String.valueOf(state.objects[1]) +
+                state.constantStringParts[2] + String.valueOf(state.objects[2]) +
+                        state.constantStringParts[3]
+        );
+    }
+
+    @Benchmark
+    public void stringBuilder(Blackhole bh, BState state) {
+        final StringBuilder sb = new StringBuilder(state.constantStringParts[0]);
+        sb.append(state.objects[0]);
+        sb.append(state.constantStringParts[1]);
+        sb.append(state.objects[1]);
+        sb.append(state.constantStringParts[2]);
+        sb.append(state.objects[2]);
+        sb.append(state.constantStringParts[3]);
+        bh.consume(sb.toString());
+    }
+
+    @Benchmark
+    public void stringFormat(Blackhole bh, BState state) {
+        bh.consume(
+                String.format("Some wonderful %s has %d fields, and it contains %f different values.",state.objects)
+        );
+    }
+
+    @Benchmark
+    public void strSubstitutor(Blackhole bh, BState state) {
+        bh.consume(StrSubstitutor.replace(
+                "Some wonderful ${string} has ${long} fields, and it contains ${double} different values.",
+                state.namedArgs
+        ));
+    }
+
+    @Benchmark
+    public void jmte(Blackhole bh, BState state) {
+
+        bh.consume(
+                state.jmteTemplate.transform(state.namedArgs, Locale.ENGLISH)
+        );
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(StringFormat.class.getSimpleName())
+                .warmupIterations(2)
+                .measurementIterations(5)
+                .threads(1)
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+}


### PR DESCRIPTION
Currently only a few benchmarks.

Apart from the obvious candidates `+` and `StringBuilder` which are fine but cumbersome, `String.format` is way too slow.
The contenders `StrSubstitutor` (from commons-lang) and `JMTE` (both already dependencies) are okish, but require a map as input because both insist on named substitutions.
We might be able to bridge them to a renderer that looks are the declared variables of the `EvaluationContext` as well as message fields, but that's not done yet.

Connects #95 

Interestingly `StrSubstitutor` seems to use less memory than the others.
<details>
<summary>Benchmarks on MacBook Pro 15" Intel Core 2,8 GHz</summary>

```
# Run complete. Total time: 00:01:18

Benchmark                                                      Mode  Cnt        Score        Error   Units
StringFormat.jmte                                             thrpt   10  1407106.641 ±  32499.801   ops/s
StringFormat.jmte:·gc.alloc.rate                              thrpt   10     2286.041 ±     52.927  MB/sec
StringFormat.jmte:·gc.alloc.rate.norm                         thrpt   10     1704.001 ±      0.001    B/op
StringFormat.jmte:·gc.churn.PS_Eden_Space                     thrpt   10     2295.324 ±    180.021  MB/sec
StringFormat.jmte:·gc.churn.PS_Eden_Space.norm                thrpt   10     1710.328 ±    108.426    B/op
StringFormat.jmte:·gc.churn.PS_Survivor_Space                 thrpt   10        0.299 ±      0.172  MB/sec
StringFormat.jmte:·gc.churn.PS_Survivor_Space.norm            thrpt   10        0.223 ±      0.129    B/op
StringFormat.jmte:·gc.count                                   thrpt   10      155.000               counts
StringFormat.jmte:·gc.time                                    thrpt   10       67.000                   ms
StringFormat.plusOperator                                     thrpt   10  3948230.215 ± 273921.487   ops/s
StringFormat.plusOperator:·gc.alloc.rate                      thrpt   10     3342.960 ±    231.923  MB/sec
StringFormat.plusOperator:·gc.alloc.rate.norm                 thrpt   10      888.000 ±      0.001    B/op
StringFormat.plusOperator:·gc.churn.PS_Eden_Space             thrpt   10     3330.386 ±    195.223  MB/sec
StringFormat.plusOperator:·gc.churn.PS_Eden_Space.norm        thrpt   10      885.128 ±     30.281    B/op
StringFormat.plusOperator:·gc.churn.PS_Survivor_Space         thrpt   10        0.258 ±      0.126  MB/sec
StringFormat.plusOperator:·gc.churn.PS_Survivor_Space.norm    thrpt   10        0.069 ±      0.033    B/op
StringFormat.plusOperator:·gc.count                           thrpt   10      195.000               counts
StringFormat.plusOperator:·gc.time                            thrpt   10       88.000                   ms
StringFormat.strSubstitutor                                   thrpt   10  1383244.565 ±  67129.871   ops/s
StringFormat.strSubstitutor:·gc.alloc.rate                    thrpt   10     1677.380 ±     82.095  MB/sec
StringFormat.strSubstitutor:·gc.alloc.rate.norm               thrpt   10     1272.001 ±      0.001    B/op
StringFormat.strSubstitutor:·gc.churn.PS_Eden_Space           thrpt   10     1721.828 ±    148.321  MB/sec
StringFormat.strSubstitutor:·gc.churn.PS_Eden_Space.norm      thrpt   10     1306.272 ±    110.749    B/op
StringFormat.strSubstitutor:·gc.churn.PS_Survivor_Space       thrpt   10        0.224 ±      0.115  MB/sec
StringFormat.strSubstitutor:·gc.churn.PS_Survivor_Space.norm  thrpt   10        0.170 ±      0.086    B/op
StringFormat.strSubstitutor:·gc.count                         thrpt   10      113.000               counts
StringFormat.strSubstitutor:·gc.time                          thrpt   10       50.000                   ms
StringFormat.stringBuilder                                    thrpt   10  4263299.390 ± 193002.567   ops/s
StringFormat.stringBuilder:·gc.alloc.rate                     thrpt   10     3219.321 ±    145.558  MB/sec
StringFormat.stringBuilder:·gc.alloc.rate.norm                thrpt   10      792.000 ±      0.001    B/op
StringFormat.stringBuilder:·gc.churn.PS_Eden_Space            thrpt   10     3223.601 ±    184.422  MB/sec
StringFormat.stringBuilder:·gc.churn.PS_Eden_Space.norm       thrpt   10      792.960 ±     20.406    B/op
StringFormat.stringBuilder:·gc.churn.PS_Survivor_Space        thrpt   10        0.268 ±      0.116  MB/sec
StringFormat.stringBuilder:·gc.churn.PS_Survivor_Space.norm   thrpt   10        0.066 ±      0.029    B/op
StringFormat.stringBuilder:·gc.count                          thrpt   10      214.000               counts
StringFormat.stringBuilder:·gc.time                           thrpt   10       91.000                   ms
StringFormat.stringFormat                                     thrpt   10   705007.041 ±  20884.918   ops/s
StringFormat.stringFormat:·gc.alloc.rate                      thrpt   10     1629.414 ±     48.286  MB/sec
StringFormat.stringFormat:·gc.alloc.rate.norm                 thrpt   10     2424.001 ±      0.001    B/op
StringFormat.stringFormat:·gc.churn.PS_Eden_Space             thrpt   10     1634.521 ±    100.133  MB/sec
StringFormat.stringFormat:·gc.churn.PS_Eden_Space.norm        thrpt   10     2431.655 ±    133.517    B/op
StringFormat.stringFormat:·gc.churn.PS_Survivor_Space         thrpt   10        0.302 ±      0.130  MB/sec
StringFormat.stringFormat:·gc.churn.PS_Survivor_Space.norm    thrpt   10        0.449 ±      0.188    B/op
StringFormat.stringFormat:·gc.count                           thrpt   10      168.000               counts
StringFormat.stringFormat:·gc.time                            thrpt   10       76.000                   ms
```
</details>