### PR TITLE
Date arithmetic

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/AdditionExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/AdditionExpression.java
@@ -18,6 +18,9 @@ package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
 import org.antlr.v4.runtime.Token;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.joda.time.Period;
 
 import javax.annotation.Nullable;
 
@@ -53,6 +56,43 @@ public class AdditionExpression extends BinaryExpression implements NumericExpre
         final Object leftValue = left.evaluateUnsafe(context);
         final Object rightValue = right.evaluateUnsafe(context);
 
+        // special case for date arithmetic
+        final boolean leftDate = DateTime.class.equals(leftValue.getClass());
+        final boolean leftPeriod = Period.class.equals(leftValue.getClass());
+        final boolean rightDate = DateTime.class.equals(rightValue.getClass());
+        final boolean rightPeriod = Period.class.equals(rightValue.getClass());
+
+        if (leftDate && rightPeriod) {
+            final DateTime date = (DateTime) leftValue;
+            final Period period = (Period) rightValue;
+
+            return isPlus() ? date.plus(period) : date.minus(period);
+        } else if (leftPeriod && rightDate) {
+            final DateTime date = (DateTime) rightValue;
+            final Period period = (Period) leftValue;
+
+            return isPlus() ? date.plus(period) : date.minus(period);
+        } else if (leftPeriod && rightPeriod) {
+            final Period period1 = (Period) leftValue;
+            final Period period2 = (Period) rightValue;
+
+            return isPlus() ? period1.plus(period2) : period1.minus(period2);
+        } else if (leftDate && rightDate) {
+            // the most uncommon, this is only defined for - really and means "interval between them"
+            // because adding two dates makes no sense
+            if (isPlus()) {
+                // makes no sense to compute and should be handles in the parser already
+                return null;
+            }
+            final DateTime left = (DateTime) leftValue;
+            final DateTime right = (DateTime) rightValue;
+
+            if (left.isBefore(right)) {
+                return new Duration(left, right);
+            } else {
+                return new Duration(right, left);
+            }
+        }
         if (isIntegral()) {
             final long l = (long) leftValue;
             final long r = (long) rightValue;

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/codegen/CodeGenerator.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/codegen/CodeGenerator.java
@@ -406,7 +406,6 @@ public class CodeGenerator {
             final CodeBlock leftBlock = codeSnippet.get(expr.left());
             final CodeBlock rightBlock = codeSnippet.get(expr.right());
 
-            // TODO optimize operator selection, Objects.equals isn't the ideal candidate because of auto-boxing
             final Class leftType = expr.left().getType();
             final Class rightType = expr.right().getType();
             boolean useOperator = false;

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/codegen/CodeGenerator.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/codegen/CodeGenerator.java
@@ -55,6 +55,9 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.statements.VarAssignStatement;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -419,6 +422,20 @@ public class CodeGenerator {
                         blockOrMissing(leftBlock, expr.left()),
                         blockOrMissing(rightBlock, expr.right()));
             } else {
+                // Dates
+                if (DateTime.class.equals(leftType)) {
+                    if (DateTime.class.equals(rightType)) {
+                        codeSnippet.putIfAbsent(expr, CodeBlock.of("$L.isEqual($L)", leftBlock, rightBlock));
+                        return;
+                    }
+                } else if (Period.class.equals(leftType)) {
+                    if (Period.class.equals(rightType)) {
+                        codeSnippet.putIfAbsent(expr,
+                                CodeBlock.of("$L.toDuration().equals($L.toDuration())", leftBlock, rightBlock));
+                        return;
+                    }
+                }
+
                 statement += (checkEquality ? "" : "!") + "$T.equals($L, $L)";
                 currentMethod.addStatement(statement,
                         intermediateName,
@@ -434,7 +451,45 @@ public class CodeGenerator {
         public void exitComparison(ComparisonExpression expr) {
             final CodeBlock left = codeSnippet.get(expr.left());
             final CodeBlock right = codeSnippet.get(expr.right());
-            // TODO dates
+
+            final Class leftType = expr.left().getType();
+            final Class rightType = expr.right().getType();
+
+            if (DateTime.class.equals(leftType)) {
+                if (DateTime.class.equals(rightType)) {
+                    CodeBlock block;
+                    switch (expr.getOperator()) {
+                        case ">":
+                            block = CodeBlock.of("$L.isAfter($L)", left, right);
+                            break;
+                        case ">=":
+                            block = CodeBlock.of("!$L.isBefore($L)", left, right);
+                            break;
+                        case "<":
+                            block = CodeBlock.of("$L.isBefore($L)", left, right);
+                            break;
+                        case "<=":
+                            block = CodeBlock.of("!$L.isAfter($L)", left, right);
+                            break;
+                        default:
+                            block = null;
+                    }
+                    if (block != null) {
+                        codeSnippet.putIfAbsent(expr, block);
+                        return;
+                    }
+                }
+            } else if (Period.class.equals(leftType)) {
+                if (Period.class.equals(rightType)) {
+                    codeSnippet.putIfAbsent(expr,
+                            CodeBlock.of("($L.toDuration().getMillis() " + expr.getOperator() + " $L.toDuration().getMillis())",
+                                    blockOrMissing(left, expr.left()),
+                                    blockOrMissing(right, expr.right())));
+                    return;
+
+                }
+            }
+
             codeSnippet.putIfAbsent(expr, CodeBlock.of("($L " + expr.getOperator() + " $L)",
                     blockOrMissing(left, expr.left()),
                     blockOrMissing(right, expr.right())));
@@ -558,6 +613,36 @@ public class CodeGenerator {
         public void exitAddition(AdditionExpression expr) {
             final Object leftBlock = blockOrMissing(codeSnippet.get(expr.left()), expr.left());
             final Object rightBlock = blockOrMissing(codeSnippet.get(expr.right()), expr.right());
+
+            Class leftType = expr.left().getType();
+            Class rightType = expr.right().getType();
+
+            if (DateTime.class.equals(leftType)) {
+                if (DateTime.class.equals(rightType)) {
+                    // calculate duration between two dates (adding two dates is invalid)
+                    if (expr.isPlus()) {
+                        throw new IllegalStateException("Cannot add two dates, this is a parser bug");
+                    }
+                    codeSnippet.putIfAbsent(expr, CodeBlock.of(
+                            "new $T($L, $L)", Duration.class, leftBlock, rightBlock));
+                } else if (Period.class.equals(rightType)) {
+                    // new datetime
+                    codeSnippet.putIfAbsent(expr,
+                            CodeBlock.of("$L." + (expr.isPlus() ? "plus" : "minus") + "($L)", leftBlock, rightBlock));
+                }
+                return;
+            } else if (Period.class.equals(leftType)) {
+                if (DateTime.class.equals(rightType)) {
+                    // invert the arguments, adding the period to the date, yielding a new DateTime
+                    codeSnippet.putIfAbsent(expr,
+                            CodeBlock.of("$L." + (expr.isPlus() ? "plus" : "minus") + "($L)", rightBlock, leftBlock));
+                } else if (Period.class.equals(rightType)) {
+                    // adding two periods yields a new period
+                    codeSnippet.putIfAbsent(expr,
+                            CodeBlock.of("$L." + (expr.isPlus() ? "plus" : "minus") + "($L)", leftBlock, rightBlock));
+                }
+                return;
+            }
 
             codeSnippet.putIfAbsent(expr,
                     CodeBlock.of("$L " + (expr.isPlus() ? "+" : "-") + " $L", leftBlock, rightBlock));

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -19,6 +19,7 @@ package org.graylog.plugins.pipelineprocessor.functions;
 import com.google.inject.Binder;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
+
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.BooleanConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.DoubleConversion;
@@ -28,6 +29,15 @@ import org.graylog.plugins.pipelineprocessor.functions.dates.FlexParseDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FormatDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.Now;
 import org.graylog.plugins.pipelineprocessor.functions.dates.ParseDate;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Days;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Hours;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Millis;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Minutes;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Months;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.PeriodParseFunction;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Seconds;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Weeks;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Years;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32C;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.MD5;
@@ -115,6 +125,15 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(ParseDate.NAME, ParseDate.class);
         addMessageProcessorFunction(FlexParseDate.NAME, FlexParseDate.class);
         addMessageProcessorFunction(FormatDate.NAME, FormatDate.class);
+        addMessageProcessorFunction(Years.NAME, Years.class);
+        addMessageProcessorFunction(Months.NAME, Months.class);
+        addMessageProcessorFunction(Weeks.NAME, Weeks.class);
+        addMessageProcessorFunction(Days.NAME, Days.class);
+        addMessageProcessorFunction(Hours.NAME, Hours.class);
+        addMessageProcessorFunction(Minutes.NAME, Minutes.class);
+        addMessageProcessorFunction(Seconds.NAME, Seconds.class);
+        addMessageProcessorFunction(Millis.NAME, Millis.class);
+        addMessageProcessorFunction(PeriodParseFunction.NAME, PeriodParseFunction.class);
 
         // hash digest
         addMessageProcessorFunction(CRC32.NAME, CRC32.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/AbstractPeriodComponentFunction.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/AbstractPeriodComponentFunction.java
@@ -1,0 +1,50 @@
+package org.graylog.plugins.pipelineprocessor.functions.dates.periods;
+
+import com.google.common.primitives.Ints;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.joda.time.Period;
+
+import javax.annotation.Nonnull;
+
+public abstract class AbstractPeriodComponentFunction extends AbstractFunction<Period> {
+
+    private final ParameterDescriptor<Long, Period> value =
+            ParameterDescriptor
+                    .integer("value", Period.class)
+                    .transform(this::getPeriodOfInt)
+                    .build();
+
+    private Period getPeriodOfInt(long period) {
+        return getPeriod(Ints.saturatedCast(period));
+    }
+
+    @Nonnull
+    protected abstract Period getPeriod(int period);
+
+    @Override
+    public Period evaluate(FunctionArgs args, EvaluationContext context) {
+        return value.required(args, context);
+    }
+
+    @Override
+    public FunctionDescriptor<Period> descriptor() {
+        return FunctionDescriptor.<Period>builder()
+                .name(getName())
+                .description(getDescription())
+                .pure(true)
+                .returnType(Period.class)
+                .params(value)
+                .build();
+    }
+
+    @Nonnull
+    protected abstract String getName();
+
+    @Nonnull
+    protected abstract String getDescription();
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Days.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Days.java
@@ -1,0 +1,28 @@
+package org.graylog.plugins.pipelineprocessor.functions.dates.periods;
+
+import org.joda.time.Period;
+
+import javax.annotation.Nonnull;
+
+public class Days extends AbstractPeriodComponentFunction {
+
+    public static final String NAME = "days";
+
+    @Nonnull
+    @Override
+    protected Period getPeriod(int period) {
+        return Period.days(period);
+    }
+
+    @Nonnull
+    @Override
+    protected String getName() {
+        return NAME;
+    }
+
+    @Nonnull
+    @Override
+    protected String getDescription() {
+        return "Create a period with a specified number of days.";
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Hours.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Hours.java
@@ -1,0 +1,28 @@
+package org.graylog.plugins.pipelineprocessor.functions.dates.periods;
+
+import org.joda.time.Period;
+
+import javax.annotation.Nonnull;
+
+public class Hours extends AbstractPeriodComponentFunction {
+
+    public static final String NAME = "hours";
+
+    @Nonnull
+    @Override
+    protected Period getPeriod(int period) {
+        return Period.hours(period);
+    }
+
+    @Nonnull
+    @Override
+    protected String getName() {
+        return NAME;
+    }
+
+    @Nonnull
+    @Override
+    protected String getDescription() {
+        return "Create a period with a specified number of hours.";
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Millis.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Millis.java
@@ -1,0 +1,28 @@
+package org.graylog.plugins.pipelineprocessor.functions.dates.periods;
+
+import org.joda.time.Period;
+
+import javax.annotation.Nonnull;
+
+public class Millis extends AbstractPeriodComponentFunction {
+
+    public static final String NAME = "millis";
+
+    @Nonnull
+    @Override
+    protected Period getPeriod(int period) {
+        return Period.millis(period);
+    }
+
+    @Nonnull
+    @Override
+    protected String getName() {
+        return NAME;
+    }
+
+    @Nonnull
+    @Override
+    protected String getDescription() {
+        return "Create a period with a specified number of millis.";
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Minutes.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Minutes.java
@@ -1,0 +1,28 @@
+package org.graylog.plugins.pipelineprocessor.functions.dates.periods;
+
+import org.joda.time.Period;
+
+import javax.annotation.Nonnull;
+
+public class Minutes extends AbstractPeriodComponentFunction {
+
+    public static final String NAME = "minutes";
+
+    @Nonnull
+    @Override
+    protected Period getPeriod(int period) {
+        return Period.minutes(period);
+    }
+
+    @Nonnull
+    @Override
+    protected String getName() {
+        return NAME;
+    }
+
+    @Nonnull
+    @Override
+    protected String getDescription() {
+        return "Create a period with a specified number of minutes.";
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Months.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Months.java
@@ -1,0 +1,28 @@
+package org.graylog.plugins.pipelineprocessor.functions.dates.periods;
+
+import org.joda.time.Period;
+
+import javax.annotation.Nonnull;
+
+public class Months extends AbstractPeriodComponentFunction {
+
+    public static final String NAME = "months";
+
+    @Nonnull
+    @Override
+    protected Period getPeriod(int period) {
+        return Period.months(period);
+    }
+
+    @Nonnull
+    @Override
+    protected String getName() {
+        return NAME;
+    }
+
+    @Nonnull
+    @Override
+    protected String getDescription() {
+        return "Create a period with a specified number of months.";
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/PeriodParseFunction.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/PeriodParseFunction.java
@@ -1,0 +1,35 @@
+package org.graylog.plugins.pipelineprocessor.functions.dates.periods;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.joda.time.Period;
+
+public class PeriodParseFunction extends AbstractFunction<Period> {
+
+    public static final String NAME = "period";
+    private final ParameterDescriptor<String, Period> value =
+            ParameterDescriptor
+                    .string("value", Period.class)
+                    .transform(Period::parse)
+                    .build();
+
+
+    @Override
+    public Period evaluate(FunctionArgs args, EvaluationContext context) {
+        return value.required(args, context);
+    }
+
+    @Override
+    public FunctionDescriptor<Period> descriptor() {
+        return FunctionDescriptor.<Period>builder()
+                .name(NAME)
+                .description("Parses a ISO 8601 period from the specified string.")
+                .pure(true)
+                .returnType(Period.class)
+                .params(value)
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Seconds.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Seconds.java
@@ -1,0 +1,28 @@
+package org.graylog.plugins.pipelineprocessor.functions.dates.periods;
+
+import org.joda.time.Period;
+
+import javax.annotation.Nonnull;
+
+public class Seconds extends AbstractPeriodComponentFunction {
+
+    public static final String NAME = "seconds";
+
+    @Nonnull
+    @Override
+    protected Period getPeriod(int period) {
+        return Period.seconds(period);
+    }
+
+    @Nonnull
+    @Override
+    protected String getName() {
+        return NAME;
+    }
+
+    @Nonnull
+    @Override
+    protected String getDescription() {
+        return "Create a period with a specified number of seconds.";
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Weeks.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Weeks.java
@@ -1,0 +1,28 @@
+package org.graylog.plugins.pipelineprocessor.functions.dates.periods;
+
+import org.joda.time.Period;
+
+import javax.annotation.Nonnull;
+
+public class Weeks extends AbstractPeriodComponentFunction {
+
+    public static final String NAME = "weeks";
+
+    @Nonnull
+    @Override
+    protected Period getPeriod(int period) {
+        return Period.weeks(period);
+    }
+
+    @Nonnull
+    @Override
+    protected String getName() {
+        return NAME;
+    }
+
+    @Nonnull
+    @Override
+    protected String getDescription() {
+        return "Create a period with a specified number of weeks.";
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Years.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/Years.java
@@ -1,0 +1,30 @@
+package org.graylog.plugins.pipelineprocessor.functions.dates.periods;
+
+import org.joda.time.Period;
+
+import javax.annotation.Nonnull;
+
+import static com.google.common.primitives.Ints.saturatedCast;
+
+public class Years extends AbstractPeriodComponentFunction {
+
+    public static final String NAME = "years";
+
+    @Override
+    @Nonnull
+    protected Period getPeriod(int period) {
+        return Period.years(saturatedCast(period));
+    }
+
+    @Override
+    @Nonnull
+    protected String getName() {
+        return NAME;
+    }
+
+    @Nonnull
+    @Override
+    protected String getDescription() {
+        return "Create a period with a specified number of years.";
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/errors/InvalidOperation.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/errors/InvalidOperation.java
@@ -1,0 +1,32 @@
+package org.graylog.plugins.pipelineprocessor.parser.errors;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.graylog.plugins.pipelineprocessor.ast.expressions.Expression;
+
+public class InvalidOperation extends ParseError {
+    private final Expression expr;
+
+    private final String message;
+
+    public InvalidOperation(ParserRuleContext ctx, Expression expr, String message) {
+        super("invalid_operation", ctx);
+        this.expr = expr;
+        this.message = message;
+    }
+
+    @JsonProperty("reason")
+    @Override
+    public String toString() {
+        return "Invalid operation: " + message;
+    }
+
+    public Expression getExpression() {
+        return expr;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -16,12 +16,14 @@
  */
 package org.graylog.plugins.pipelineprocessor.functions;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.net.InetAddresses;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.graylog.plugins.pipelineprocessor.BaseParserTest;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
@@ -34,6 +36,15 @@ import org.graylog.plugins.pipelineprocessor.functions.dates.FlexParseDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FormatDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.Now;
 import org.graylog.plugins.pipelineprocessor.functions.dates.ParseDate;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Days;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Hours;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Millis;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Minutes;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Months;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.PeriodParseFunction;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Seconds;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Weeks;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Years;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32C;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.MD5;
@@ -85,6 +96,7 @@ import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.graylog2.streams.StreamService;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
+import org.joda.time.Duration;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -160,6 +172,16 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(FlexParseDate.NAME, new FlexParseDate());
         functions.put(ParseDate.NAME, new ParseDate());
         functions.put(FormatDate.NAME, new FormatDate());
+
+        functions.put(Years.NAME, new Years());
+        functions.put(Months.NAME, new Months());
+        functions.put(Weeks.NAME, new Weeks());
+        functions.put(Days.NAME, new Days());
+        functions.put(Hours.NAME, new Hours());
+        functions.put(Minutes.NAME, new Minutes());
+        functions.put(Seconds.NAME, new Seconds());
+        functions.put(Millis.NAME, new Millis());
+        functions.put(PeriodParseFunction.NAME, new PeriodParseFunction());
 
         functions.put(CRC32.NAME, new CRC32());
         functions.put(CRC32C.NAME, new CRC32C());
@@ -572,6 +594,24 @@ public class FunctionsSnippetsTest extends BaseParserTest {
             evaluateRule(rule);
 
             assertThat(actionsTriggered.get()).isTrue();
+        } finally {
+            DateTimeUtils.setCurrentMillisSystem();
+        }
+    }
+
+    @Test
+    public void dateArithmetic() {
+        final InstantMillisProvider clock = new InstantMillisProvider(GRAYLOG_EPOCH);
+        DateTimeUtils.setCurrentMillisProvider(clock);
+        try {
+            final Rule rule = parser.parseRule(ruleForTest(), true);
+            final Message message = evaluateRule(rule);
+
+            assertThat(actionsTriggered.get()).isTrue();
+            assertThat(message).isNotNull();
+            assertThat(message.getField("interval"))
+                    .isInstanceOf(Duration.class)
+                    .matches(o -> ((Duration)o).isEqual(Duration.standardDays(1)), "Exactly one day difference");
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
         }

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -97,6 +97,7 @@ import org.graylog2.streams.StreamService;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
+import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -612,6 +613,18 @@ public class FunctionsSnippetsTest extends BaseParserTest {
             assertThat(message.getField("interval"))
                     .isInstanceOf(Duration.class)
                     .matches(o -> ((Duration)o).isEqual(Duration.standardDays(1)), "Exactly one day difference");
+            assertThat(message.getField("years")).isEqualTo(Period.years(2));
+            assertThat(message.getField("months")).isEqualTo(Period.months(2));
+            assertThat(message.getField("weeks")).isEqualTo(Period.weeks(2));
+            assertThat(message.getField("days")).isEqualTo(Period.days(2));
+            assertThat(message.getField("hours")).isEqualTo(Period.hours(2));
+            assertThat(message.getField("minutes")).isEqualTo(Period.minutes(2));
+            assertThat(message.getField("seconds")).isEqualTo(Period.seconds(2));
+            assertThat(message.getField("millis")).isEqualTo(Period.millis(2));
+            assertThat(message.getField("period")).isEqualTo(Period.parse("P1YT1M"));
+
+
+            assertThat(message.getFieldAs(DateTime.class, "long_time_ago")).matches(date -> date.plus(Period.years(10000)).equals(GRAYLOG_EPOCH));
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
         }

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
@@ -33,7 +33,17 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.LongConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
+import org.graylog.plugins.pipelineprocessor.functions.dates.Now;
 import org.graylog.plugins.pipelineprocessor.functions.dates.TimezoneAwareFunction;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Days;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Hours;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Millis;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Minutes;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Months;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.PeriodParseFunction;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Seconds;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Weeks;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Years;
 import org.graylog.plugins.pipelineprocessor.functions.messages.HasField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
 import org.graylog.plugins.pipelineprocessor.functions.strings.RegexMatch;
@@ -46,8 +56,10 @@ import org.graylog.plugins.pipelineprocessor.parser.errors.OptionalParametersMus
 import org.graylog.plugins.pipelineprocessor.parser.errors.ParseError;
 import org.graylog.plugins.pipelineprocessor.parser.errors.UndeclaredFunction;
 import org.graylog.plugins.pipelineprocessor.parser.errors.UndeclaredVariable;
+import org.graylog2.plugin.InstantMillisProvider;
 import org.graylog2.plugin.Message;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.junit.Assert;
@@ -61,6 +73,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.of;
+import static org.graylog.plugins.pipelineprocessor.functions.FunctionsSnippetsTest.GRAYLOG_EPOCH;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -91,6 +104,18 @@ public class PipelineRuleParserTest extends BaseParserTest {
         functions.put(HasField.NAME, new HasField());
         functions.put(RegexMatch.NAME, new RegexMatch());
         functions.put("now_in_tz", new NowInTimezoneFunction());
+
+        functions.put(Now.NAME, new Now());
+        functions.put(Years.NAME, new Years());
+        functions.put(Months.NAME, new Months());
+        functions.put(Weeks.NAME, new Weeks());
+        functions.put(Days.NAME, new Days());
+        functions.put(Hours.NAME, new Hours());
+        functions.put(Minutes.NAME, new Minutes());
+        functions.put(Seconds.NAME, new Seconds());
+        functions.put(Millis.NAME, new Millis());
+        functions.put(PeriodParseFunction.NAME, new PeriodParseFunction());
+
         functionRegistry = new FunctionRegistry(functions);
     }
 
@@ -342,10 +367,25 @@ public class PipelineRuleParserTest extends BaseParserTest {
 
     @Test
     public void booleanNot() {
-        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final Rule rule = parseRuleWithOptionalCodegen();
         evaluateRule(rule);
 
         assertFalse(actionsTriggered.get());
+    }
+
+    @Test
+    public void dateArithmetic() {
+        final InstantMillisProvider clock = new InstantMillisProvider(GRAYLOG_EPOCH);
+        DateTimeUtils.setCurrentMillisProvider(clock);
+        try {
+            final Rule rule = parseRuleWithOptionalCodegen();
+            final Message message = evaluateRule(rule);
+            assertNotNull(message);
+            assertTrue(actionsTriggered.get());
+        } finally {
+            DateTimeUtils.setCurrentMillisSystem();
+        }
+
     }
 
     public static class CustomObject {

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
@@ -51,6 +51,7 @@ import org.graylog.plugins.pipelineprocessor.parser.errors.IncompatibleArgumentT
 import org.graylog.plugins.pipelineprocessor.parser.errors.IncompatibleIndexType;
 import org.graylog.plugins.pipelineprocessor.parser.errors.IncompatibleTypes;
 import org.graylog.plugins.pipelineprocessor.parser.errors.InvalidFunctionArgument;
+import org.graylog.plugins.pipelineprocessor.parser.errors.InvalidOperation;
 import org.graylog.plugins.pipelineprocessor.parser.errors.NonIndexableType;
 import org.graylog.plugins.pipelineprocessor.parser.errors.OptionalParametersMustBeNamed;
 import org.graylog.plugins.pipelineprocessor.parser.errors.ParseError;
@@ -387,6 +388,18 @@ public class PipelineRuleParserTest extends BaseParserTest {
         }
 
     }
+
+    @Test
+    public void invalidDateAddition() {
+        try {
+            parseRuleWithOptionalCodegen();
+            fail("Should have thrown parse exception");
+        } catch (ParseException e) {
+            assertEquals(1, e.getErrors().size());
+            assertEquals(InvalidOperation.class, Iterables.getOnlyElement(e.getErrors()).getClass());
+        }
+    }
+
 
     public static class CustomObject {
         private final String id;

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dateArithmetic.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dateArithmetic.txt
@@ -1,0 +1,27 @@
+// now() is fixed to "2010-07-30T18:03:25+02:00" to provide a better testing experience
+rule "date math"
+when
+    now() + years(1) > now() &&
+    now() + months(1) > now() &&
+    now() + weeks(1) > now() &&
+    now() + days(1) > now() &&
+    now() + hours(1) > now() &&
+    now() + minutes(1) > now() &&
+    now() + seconds(1) > now() &&
+    now() + millis(1) > now() &&
+    now() + period("P1YT1M") > now() &&
+
+    now() - years(1) < now() &&
+    now() - months(1) < now() &&
+    now() - weeks(1) < now() &&
+    now() - days(1) < now() &&
+    now() - hours(1) < now() &&
+    now() - minutes(1) < now() &&
+    now() - seconds(1) < now() &&
+    now() - millis(1) < now() &&
+    now() - period("P1YT1M") < now()
+
+then
+    set_field("interval", now() - (now() - days(1))); // is a duration of 1 day
+    trigger_test();
+end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dateArithmetic.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dateArithmetic.txt
@@ -23,5 +23,17 @@ when
 
 then
     set_field("interval", now() - (now() - days(1))); // is a duration of 1 day
+    set_field("long_time_ago", now() - years(10000));
+    set_fields({
+      years: years(2),
+      months: months(2),
+      weeks: weeks(2),
+      days: days(2),
+      hours: hours(2),
+      minutes: minutes(2),
+      seconds: seconds(2),
+      millis: millis(2),
+      period: period("P1YT1M")
+    });
     trigger_test();
 end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/parser/dateArithmetic.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/parser/dateArithmetic.txt
@@ -1,0 +1,27 @@
+// now() is fixed to "2010-07-30T18:03:25+02:00" to provide a better testing experience
+rule "date math"
+when
+    now() + years(1) > now() &&
+    now() + months(1) > now() &&
+    now() + weeks(1) > now() &&
+    now() + days(1) > now() &&
+    now() + hours(1) > now() &&
+    now() + minutes(1) > now() &&
+    now() + seconds(1) > now() &&
+    now() + millis(1) > now() &&
+    now() + period("P1YT1M") > now() &&
+
+    now() - years(1) < now() &&
+    now() - months(1) < now() &&
+    now() - weeks(1) < now() &&
+    now() - days(1) < now() &&
+    now() - hours(1) < now() &&
+    now() - minutes(1) < now() &&
+    now() - seconds(1) < now() &&
+    now() - millis(1) < now() &&
+    now() - period("P1YT1M") < now()
+
+then
+    set_field("interval", now() - (now() - days(1))); // is a duration of 1 day
+    trigger_test();
+end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/parser/invalidDateAddition.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/parser/invalidDateAddition.txt
@@ -1,0 +1,4 @@
+rule "cannot add dates"
+when
+    now() + now() == now()
+end


### PR DESCRIPTION
This change introduces simple arithmetics on DateTime and Period types.

Supported operations are:
* subtracting two `DateTime` instances from each other, yielding the `Duration` between them
* adding two dates makes no sense and is not allowed (statically checked)
* adding/subtracting a `Period` and a `DateTime` instance (commutative operation)
* adding/subtracting two `Period`s

To be able to have type safety for these operations, various `Period` creating functions are introduced:
* `years()`
* `months()`
* `weeks()`
* `days()`
* `hours()`
* `minutes()`
* `seconds()`
* `millis()`
* `period()` taking an ISO8601 period string for arbitrary periods

The date types can also be compared with all equality and comparison functions.