### PR TITLE
do not register cache gauges more than once

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.assistedinject.Assisted;
+
 import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
 import org.graylog.plugins.pipelineprocessor.db.PipelineService;
 import org.graylog.plugins.pipelineprocessor.processors.ConfigurationStateUpdater;
@@ -34,11 +35,12 @@ import org.graylog2.plugin.decorators.SearchResponseDecorator;
 import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
 import org.graylog2.rest.resources.search.responses.SearchResponse;
 
-import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import javax.inject.Inject;
 
 public class PipelineProcessorMessageDecorator implements SearchResponseDecorator {
     private static final String CONFIG_FIELD_PIPELINE = "pipeline";
@@ -125,8 +127,6 @@ public class PipelineProcessorMessageDecorator implements SearchResponseDecorato
                 ));
             });
         });
-
-        pipelineInterpreter.stop();
 
         return searchResponse.toBuilder().messages(results).build();
     }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
@@ -86,6 +86,8 @@ public class ConfigurationStateUpdater {
 
         // listens to cluster wide Rule, Pipeline and pipeline stream connection changes
         serverEventBus.register(this);
+
+        reloadAndSave();
     }
 
     private static void setAllowCodeGeneration(Boolean allowCodeGeneration) {

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
@@ -86,9 +86,6 @@ public class ConfigurationStateUpdater {
 
         // listens to cluster wide Rule, Pipeline and pipeline stream connection changes
         serverEventBus.register(this);
-
-        // eagerly propagate initial state
-        serverEventBus.post(reloadAndSave());
     }
 
     private static void setAllowCodeGeneration(Boolean allowCodeGeneration) {

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
@@ -1,5 +1,6 @@
 package org.graylog.plugins.pipelineprocessor.processors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -30,6 +31,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -56,7 +58,7 @@ public class ConfigurationStateUpdater {
     /**
      * non-null if the update has successfully loaded a state
      */
-    private PipelineInterpreter.State latestState;
+    private final AtomicReference<PipelineInterpreter.State> latestState = new AtomicReference<>();
     private static boolean allowCodeGeneration = false;
 
     @Inject
@@ -89,7 +91,7 @@ public class ConfigurationStateUpdater {
         serverEventBus.post(reloadAndSave());
     }
 
-    public static void setAllowCodeGeneration(Boolean allowCodeGeneration) {
+    private static void setAllowCodeGeneration(Boolean allowCodeGeneration) {
         if (allowCodeGeneration && ToolProvider.getSystemJavaCompiler() == null) {
             log.warn("Your Java runtime does not have a compiler available, turning off dynamic " +
                     "code generation. Please consider running Graylog in a JDK, not a JRE, to " +
@@ -106,12 +108,6 @@ public class ConfigurationStateUpdater {
     // only the singleton instance should mutate itself, others are welcome to reload a new state, but we don't
     // currently allow direct global state updates from external sources (if you need to, send an event on the bus instead)
     private synchronized PipelineInterpreter.State reloadAndSave() {
-        latestState = reload();
-        return latestState;
-    }
-
-    // this should not run in parallel to avoid useless database traffic
-    public synchronized PipelineInterpreter.State reload() {
         // this classloader will hold all generated rule classes
         PipelineClassloader commonClassLoader = allowCodeGeneration ? new PipelineClassloader() : null;
 
@@ -152,8 +148,11 @@ public class ConfigurationStateUpdater {
         }
         ImmutableSetMultimap<String, Pipeline> streamPipelineConnections = ImmutableSetMultimap.copyOf(connections);
 
-        return stateFactory.newState(currentPipelines, streamPipelineConnections, commonClassLoader);
+        final PipelineInterpreter.State newState = stateFactory.newState(currentPipelines, streamPipelineConnections, commonClassLoader);
+        latestState.set(newState);
+        return newState;
     }
+
 
     /**
      * Can be used to inspect or use the current state of the pipeline system.
@@ -161,7 +160,7 @@ public class ConfigurationStateUpdater {
      * @return the currently loaded state of the updater
      */
     public PipelineInterpreter.State getLatestState() {
-        return latestState;
+        return latestState.get();
     }
 
     @Nonnull
@@ -220,4 +219,8 @@ public class ConfigurationStateUpdater {
         scheduler.schedule(() -> serverEventBus.post(reloadAndSave()), 0, TimeUnit.SECONDS);
     }
 
+    @VisibleForTesting
+    PipelineInterpreter.State reload() {
+        return reloadAndSave();
+    }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
@@ -16,9 +16,6 @@
  */
 package org.graylog.plugins.pipelineprocessor.rest;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.elasticsearch.common.Strings;
@@ -35,6 +32,9 @@ import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.streams.StreamService;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -42,8 +42,10 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.ArrayList;
-import java.util.List;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 @Api(value = "Pipelines/Simulator", description = "Simulate pipeline message processor")
 @Path("/system/pipelines/simulate")
@@ -89,7 +91,6 @@ public class SimulatorResource extends RestResource implements PluginRestResourc
             simulationResults.add(ResultMessageSummary.create(null, processedMessage.getFields(), ""));
         }
 
-        pipelineInterpreter.stop();
         return SimulationResponse.create(simulationResults,
                                          pipelineInterpreterTracer.getExecutionTrace(),
                                          pipelineInterpreterTracer.took());

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -122,7 +122,6 @@ public class PipelineInterpreterTest {
         final PipelineInterpreter interpreter = new PipelineInterpreter(
                 mock(Journal.class),
                 new MetricRegistry(),
-                mock(EventBus.class),
                 stateUpdater
         );
 
@@ -182,7 +181,6 @@ public class PipelineInterpreterTest {
         final PipelineInterpreter interpreter = new PipelineInterpreter(
                 mock(Journal.class),
                 metricRegistry,
-                mock(EventBus.class),
                 stateUpdater
         );
 


### PR DESCRIPTION
invalid re-registering of cache gauges caused pipeline state updates to fail the second time
refactor the state updating to not use event bus, but instead let the interpreter pull the state directly from the instance it has
decorators and simulator push the state into their interpreter instance, making the interpreter immutable itself.