### PR TITLE
add to_date() function for easier interaction with $message.timestamp

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -25,6 +25,7 @@ import org.graylog.plugins.pipelineprocessor.functions.conversion.BooleanConvers
 import org.graylog.plugins.pipelineprocessor.functions.conversion.DoubleConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.LongConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
+import org.graylog.plugins.pipelineprocessor.functions.dates.DateConversion;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FlexParseDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FormatDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.Now;
@@ -121,6 +122,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(SelectJsonPath.NAME, SelectJsonPath.class);
 
         // dates
+        addMessageProcessorFunction(DateConversion.NAME, DateConversion.class);
         addMessageProcessorFunction(Now.NAME, Now.class);
         addMessageProcessorFunction(ParseDate.NAME, ParseDate.class);
         addMessageProcessorFunction(FlexParseDate.NAME, FlexParseDate.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/DateConversion.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/DateConversion.java
@@ -1,0 +1,52 @@
+package org.graylog.plugins.pipelineprocessor.functions.dates;
+
+import com.google.common.collect.ImmutableList;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+public class DateConversion extends TimezoneAwareFunction {
+
+    public static final String NAME = "to_date";
+    private final ParameterDescriptor<Object, Object> value;
+
+    public DateConversion() {
+        value = ParameterDescriptor.object("value").description("The value to convert to a date").build();
+    }
+
+    @Override
+    protected DateTime evaluate(FunctionArgs args, EvaluationContext context, DateTimeZone timezone) {
+        final Object datish = value.required(args, context);
+        if (datish instanceof DateTime) {
+            return (DateTime) datish;
+        }
+        if (datish instanceof Date) {
+            return new DateTime(datish);
+        }
+        if (datish instanceof ZonedDateTime) {
+            return new DateTime(((ZonedDateTime) datish).toInstant().toEpochMilli());
+        }
+        return null;
+    }
+
+    @Override
+    protected String description() {
+        return "Converts a type to a date, useful for $message.timestamp or related message fields.";
+    }
+
+    @Override
+    protected String getName() {
+        return NAME;
+    }
+
+    @Override
+    protected ImmutableList<ParameterDescriptor> params() {
+        return ImmutableList.of(value);
+    }
+}

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -32,6 +32,7 @@ import org.graylog.plugins.pipelineprocessor.functions.conversion.BooleanConvers
 import org.graylog.plugins.pipelineprocessor.functions.conversion.DoubleConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.LongConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
+import org.graylog.plugins.pipelineprocessor.functions.dates.DateConversion;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FlexParseDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FormatDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.Now;
@@ -169,6 +170,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(JsonParse.NAME, new JsonParse(objectMapper));
         functions.put(SelectJsonPath.NAME, new SelectJsonPath(objectMapper));
 
+        functions.put(DateConversion.NAME, new DateConversion());
         functions.put(Now.NAME, new Now());
         functions.put(FlexParseDate.NAME, new FlexParseDate());
         functions.put(ParseDate.NAME, new ParseDate());
@@ -625,6 +627,8 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
 
             assertThat(message.getFieldAs(DateTime.class, "long_time_ago")).matches(date -> date.plus(Period.years(10000)).equals(GRAYLOG_EPOCH));
+
+            assertThat(message.getTimestamp()).isEqualTo(GRAYLOG_EPOCH.plusHours(1));
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
         }

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dateArithmetic.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dateArithmetic.txt
@@ -35,5 +35,7 @@ then
       millis: millis(2),
       period: period("P1YT1M")
     });
+    set_field("timestamp", to_date($message.timestamp) + hours(1));
+
     trigger_test();
 end


### PR DESCRIPTION
this function makes the following statement possible:

    set_field("timestamp", to_date($message.timestamp) + hours(1));