### PR TITLE
fix NPEs when code generation is off and a function is unresolved

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/Rule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/Rule.java
@@ -93,7 +93,8 @@ public abstract class Rule {
      */
     public void registerMetrics(MetricRegistry metricRegistry, String pipelineId, String stageId) {
         if (id() == null) {
-            throw new IllegalStateException();
+            LOG.debug("Not registering metrics for unsaved rule {}", name());
+            return;
         }
         if (id() != null) {
             globalExecuted = registerGlobalMeter(metricRegistry, "executed");

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
@@ -172,10 +172,14 @@ public class PipelineRuleParser {
 
         if (parseContext.getErrors().isEmpty()) {
             Rule parsedRule = parseContext.getRules().get(0).withId(id);
-            if (ruleClassLoader != null || ConfigurationStateUpdater.isAllowCodeGeneration()) {
-                final Class<? extends GeneratedRule> generatedClass = codeGenerator.generateCompiledRule(parsedRule, ruleClassLoader);
-                if (generatedClass != null) {
-                    parsedRule = parsedRule.toBuilder().generatedRuleClass(generatedClass).build();
+            if (ruleClassLoader != null && ConfigurationStateUpdater.isAllowCodeGeneration()) {
+                try {
+                    final Class<? extends GeneratedRule> generatedClass = codeGenerator.generateCompiledRule(parsedRule, ruleClassLoader);
+                    if (generatedClass != null) {
+                        parsedRule = parsedRule.toBuilder().generatedRuleClass(generatedClass).build();
+                    }
+                } catch (Exception e) {
+                    log.warn("Unable to compile rule {} to native code, falling back to interpreting it: {}", parsedRule.name(), e.getMessage());
                 }
             }
             return parsedRule;


### PR DESCRIPTION
there were two possible NPEs during parse checking and when compiling rules with unresolved functions