### PR TITLE
Implement split() function

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -67,6 +67,7 @@ import org.graylog.plugins.pipelineprocessor.functions.strings.GrokMatch;
 import org.graylog.plugins.pipelineprocessor.functions.strings.KeyValue;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Lowercase;
 import org.graylog.plugins.pipelineprocessor.functions.strings.RegexMatch;
+import org.graylog.plugins.pipelineprocessor.functions.strings.Split;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Substring;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Swapcase;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Uncapitalize;
@@ -116,6 +117,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(Uppercase.NAME, Uppercase.class);
         addMessageProcessorFunction(Concat.NAME, Concat.class);
         addMessageProcessorFunction(KeyValue.NAME, KeyValue.class);
+        addMessageProcessorFunction(Split.NAME, Split.class);
 
         // json
         addMessageProcessorFunction(JsonParse.NAME, JsonParse.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/Split.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/Split.java
@@ -1,0 +1,74 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.strings;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class Split extends AbstractFunction<String[]> {
+    public static final String NAME = "split";
+
+    private final ParameterDescriptor<String, Pattern> pattern;
+    private final ParameterDescriptor<String, String> value;
+    private final ParameterDescriptor<Long, Integer> limit;
+
+    public Split() {
+        pattern = ParameterDescriptor.string("pattern", Pattern.class)
+                .transform(Pattern::compile)
+                .description("The regular expression to split by, uses Java regex syntax")
+                .build();
+        value = ParameterDescriptor.string("value")
+                .description("The string to be split")
+                .build();
+        limit = ParameterDescriptor.integer("limit", Integer.class)
+                .transform(Ints::saturatedCast)
+                .description("The number of times the pattern is applied")
+                .optional()
+                .build();
+    }
+
+    @Override
+    public String[] evaluate(FunctionArgs args, EvaluationContext context) {
+        final Pattern regex = requireNonNull(pattern.required(args, context), "Argument 'pattern' cannot be 'null'");
+        final String value = requireNonNull(this.value.required(args, context), "Argument 'value' cannot be 'null'");
+
+        final int limit = this.limit.optional(args, context).orElse(0);
+        checkArgument(limit >= 0, "Argument 'limit' cannot be negative");
+        return regex.split(value, limit);
+    }
+
+    @Override
+    public FunctionDescriptor<String[]> descriptor() {
+        return FunctionDescriptor.<String[]>builder()
+                .name(NAME)
+                .pure(true)
+                .returnType(String[].class)
+                .params(ImmutableList.of(pattern, value, limit))
+                .description("Split a string around matches of this pattern (Java syntax)")
+                .build();
+    }
+}

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/split.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/split.txt
@@ -1,0 +1,9 @@
+rule "split"
+when
+    true
+then
+    set_field("limit_0", split("_", "foo_bar_baz"));
+    set_field("limit_1", split(":", "foo:bar:baz", 1));
+    set_field("limit_2", split("\\|", "foo|bar|baz", 2));
+    trigger_test();
+end


### PR DESCRIPTION
This PR implements a function modeled after [`String#split(String, int)`](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#split-java.lang.String-int-).

Fixes #98