### PR TITLE
disable native code generation until compiler interface is fixed

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineConfig.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineConfig.java
@@ -10,5 +10,5 @@ public class PipelineConfig implements PluginConfigBean {
     private boolean cachedStageIterators = true;
 
     @Parameter("generate_native_code")
-    private boolean generateNativeCode = true;
+    private boolean generateNativeCode = false;
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
@@ -81,8 +81,8 @@ public class ConfigurationStateUpdater {
         this.scheduler = scheduler;
         this.serverEventBus = serverEventBus;
         this.stateFactory = stateFactory;
-        // from global config
-        setAllowCodeGeneration(allowCodeGeneration);
+        // ignore global config, never allow generating code
+        setAllowCodeGeneration(false);
 
         // listens to cluster wide Rule, Pipeline and pipeline stream connection changes
         serverEventBus.register(this);

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/CodegenPipelineRuleParserTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/CodegenPipelineRuleParserTest.java
@@ -17,7 +17,9 @@
 package org.graylog.plugins.pipelineprocessor.parser;
 
 import org.graylog.plugins.pipelineprocessor.codegen.PipelineClassloader;
+import org.junit.Ignore;
 
+@Ignore("code generation disabled")
 public class CodegenPipelineRuleParserTest extends PipelineRuleParserTest {
 
     // runs the same tests as in PipelineRuleParserTest but with dynamic code generation turned on.

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdaterTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdaterTest.java
@@ -51,6 +51,7 @@ import org.graylog2.shared.bindings.SchedulerBindings;
 import org.graylog2.shared.bindings.providers.MetricRegistryProvider;
 import org.graylog2.streams.StreamImpl;
 import org.graylog2.streams.StreamService;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Ignore("code generation disabled")
 public class ConfigurationStateUpdaterTest {
     private static final Logger log = LoggerFactory.getLogger(ConfigurationStateUpdaterTest.class);
     private PipelineInterpreter.State reload;


### PR DESCRIPTION
this change disables the tests for codegen as well as the config option to be a no-op

connect https://github.com/Graylog2/graylog2-server/issues/3154
fix https://github.com/Graylog2/graylog2-server/issues/3154