### PR TITLE
allow duplicate stream titles in route_to_stream

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.pipelineprocessor.functions;
 
 import com.google.inject.Binder;
+import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
 
@@ -59,6 +60,7 @@ import org.graylog.plugins.pipelineprocessor.functions.messages.RenameField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RouteToStream;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetFields;
+import org.graylog.plugins.pipelineprocessor.functions.messages.StreamCacheService;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Abbreviate;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Capitalize;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Concat;
@@ -98,6 +100,8 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(DropMessage.NAME, DropMessage.class);
         addMessageProcessorFunction(CreateMessage.NAME, CreateMessage.class);
         addMessageProcessorFunction(RouteToStream.NAME, RouteToStream.class);
+        // helper service for route_to_stream
+        serviceBinder().addBinding().to(StreamCacheService.class).in(Scopes.SINGLETON);
 
         // input related functions
         addMessageProcessorFunction(FromInput.NAME, FromInput.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/StreamCacheService.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/StreamCacheService.java
@@ -17,7 +17,6 @@
 package org.graylog.plugins.pipelineprocessor.functions.messages;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.MultimapBuilder;
@@ -34,12 +33,14 @@ import org.graylog2.streams.events.StreamsChangedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -50,13 +51,13 @@ public class StreamCacheService extends AbstractIdleService {
 
     private final EventBus eventBus;
     private final StreamService streamService;
-    private ScheduledExecutorService executorService;
+    private final ScheduledExecutorService executorService;
 
-    private SortedSetMultimap<String, Stream> nameToStream = Multimaps.synchronizedSortedSetMultimap(
+    private final SortedSetMultimap<String, Stream> nameToStream = Multimaps.synchronizedSortedSetMultimap(
             MultimapBuilder.hashKeys()
                     .treeSetValues(Comparator.comparing(Stream::getId))
                     .build());
-    private Map<String, Stream> idToStream = Maps.newConcurrentMap();
+    private final Map<String, Stream> idToStream = Maps.newConcurrentMap();
 
     @Inject
     public StreamCacheService(EventBus eventBus,
@@ -84,7 +85,7 @@ public class StreamCacheService extends AbstractIdleService {
     }
 
     @VisibleForTesting
-    public void updateStreams(ImmutableSet<String> ids) {
+    public void updateStreams(Collection<String> ids) {
         for (String id : ids) {
             LOG.debug("Updating stream id/title cache for id {}", id);
             try {
@@ -124,10 +125,12 @@ public class StreamCacheService extends AbstractIdleService {
     }
 
 
+    @Nullable
     public Stream getByName(String name) {
         return Iterables.getFirst(nameToStream.get(name), null);
     }
 
+    @Nullable
     public Stream getById(String id) {
         return idToStream.get(id);
     }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/StreamCacheService.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/StreamCacheService.java
@@ -1,0 +1,131 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.messages;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import com.google.common.util.concurrent.AbstractIdleService;
+
+import org.graylog2.database.NotFoundException;
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.streams.StreamService;
+import org.graylog2.streams.events.StreamsChangedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+@Singleton
+public class StreamCacheService extends AbstractIdleService {
+    private static final Logger LOG = LoggerFactory.getLogger(StreamCacheService.class);
+
+    private final EventBus eventBus;
+    private final StreamService streamService;
+    private ScheduledExecutorService executorService;
+
+    private Multimap<String, Stream> nameToStream = Multimaps.synchronizedListMultimap(ArrayListMultimap.create());
+    private Map<String, Stream> idToStream = Maps.newConcurrentMap();
+
+    @Inject
+    public StreamCacheService(EventBus eventBus,
+                              StreamService streamService,
+                              @Named("daemonScheduler") ScheduledExecutorService executorService) {
+        this.eventBus = eventBus;
+        this.streamService = streamService;
+        this.executorService = executorService;
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+        streamService.loadAllEnabled().forEach(this::updateCache);
+        eventBus.register(this);
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        eventBus.unregister(this);
+    }
+    @Subscribe
+    public void handleStreamUpdate(StreamsChangedEvent event) {
+        executorService.schedule(() -> updateStreams(event.streamIds()), 0, TimeUnit.SECONDS);
+    }
+
+    @VisibleForTesting
+    public void updateStreams(ImmutableSet<String> ids) {
+        for (String id : ids) {
+            LOG.info("Updating id and title cache for stream id {}", id);
+            try {
+                final Stream stream = streamService.load(id);
+                if (stream.getDisabled()) {
+                    purgeCache(stream.getId());
+                } else {
+                    updateCache(stream);
+                }
+            } catch (NotFoundException e) {
+                // the stream was deleted, we only have to purge the existing entries
+                purgeCache(id);
+            }
+        }
+    }
+
+    private void purgeCache(String id) {
+        final Stream stream = idToStream.remove(id);
+        LOG.info("Purging stream id/title cache for id {}, stream {}", id, stream);
+        if (stream != null) {
+            nameToStream.remove(stream.getTitle(), stream);
+        }
+    }
+
+    private void updateCache(Stream stream) {
+        LOG.info("Updating stream id/title cache for {}/'{}'", stream.getId(), stream.getTitle());
+        idToStream.put(stream.getId(), stream);
+        nameToStream.put(stream.getTitle(), stream);
+        final Collection<Stream> streams = nameToStream.get(stream.getTitle());
+        if (streams.size() > 1) {
+            final Stream first = Iterables.getFirst(streams, stream);
+            if (first != null) {
+                LOG.warn("There are multiple streams with the same title in the system. " +
+                                "Please use Stream IDs instead of titles for these streams to " +
+                                "consistently route messages. Returning stream '{}' ({}).",
+                        first.getTitle(), first.getId());
+            }
+        }
+    }
+
+
+    public Stream getByName(String name) {
+        return Iterables.getFirst(nameToStream.get(name), null);
+    }
+
+    public Stream getById(String id) {
+        return idToStream.get(id);
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/StreamCacheService.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/StreamCacheService.java
@@ -17,7 +17,6 @@
 package org.graylog.plugins.pipelineprocessor.functions.messages;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Multimaps;
@@ -36,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
-import java.util.SortedSet;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -114,20 +112,11 @@ public class StreamCacheService extends AbstractIdleService {
         LOG.debug("Updating stream id/title cache for {}/'{}'", stream.getId(), stream.getTitle());
         idToStream.put(stream.getId(), stream);
         nameToStream.put(stream.getTitle(), stream);
-        final SortedSet<Stream> streams = nameToStream.get(stream.getTitle());
-        if (streams.size() > 1) {
-            final Stream first = streams.first();
-            LOG.warn("There are multiple streams with the same title in the system. " +
-                            "Please use Stream IDs instead of titles for these streams to " +
-                            "consistently route messages. Returning stream '{}' for title '{}'.",
-                    first.getId(), first.getTitle());
-        }
     }
 
 
-    @Nullable
-    public Stream getByName(String name) {
-        return Iterables.getFirst(nameToStream.get(name), null);
+    public Collection<Stream> getByName(String name) {
+        return nameToStream.get(name);
     }
 
     @Nullable

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -688,7 +688,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getStreams()).isNotEmpty();
         assertThat(message.getStreams().size()).isEqualTo(1);
         final Stream stream = Iterables.getOnlyElement(message.getStreams());
-        assertThat(stream.getId()).isEqualTo("id2");
+        assertThat(stream.getId()).isEqualTo("id");
 
         streamCacheService.updateStreams(ImmutableSet.of("id"));
 

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -686,16 +686,12 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
         assertThat(message).isNotNull();
         assertThat(message.getStreams()).isNotEmpty();
-        assertThat(message.getStreams().size()).isEqualTo(1);
-        final Stream stream = Iterables.getOnlyElement(message.getStreams());
-        assertThat(stream.getId()).isEqualTo("id");
+        assertThat(message.getStreams().size()).isEqualTo(2);
 
         streamCacheService.updateStreams(ImmutableSet.of("id"));
 
         final Message message2 = evaluateRule(rule);
         assertThat(message2).isNotNull();
-        assertThat(message2.getStreams().size()).isEqualTo(1);
-        final Stream stream2 = Iterables.getOnlyElement(message2.getStreams());
-        assertThat(stream2.getId()).isEqualTo("id");
+        assertThat(message2.getStreams().size()).isEqualTo(2);
     }
 }

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -16,12 +16,15 @@
  */
 package org.graylog.plugins.pipelineprocessor.functions;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.net.InetAddresses;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.graylog.plugins.pipelineprocessor.BaseParserTest;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
@@ -65,6 +68,7 @@ import org.graylog.plugins.pipelineprocessor.functions.messages.RenameField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RouteToStream;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetFields;
+import org.graylog.plugins.pipelineprocessor.functions.messages.StreamCacheService;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Abbreviate;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Capitalize;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Concat;
@@ -85,6 +89,7 @@ import org.graylog.plugins.pipelineprocessor.functions.syslog.SyslogPriorityToSt
 import org.graylog.plugins.pipelineprocessor.functions.urls.UrlConversion;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog.plugins.pipelineprocessor.parser.ParseException;
+import org.graylog2.database.NotFoundException;
 import org.graylog2.grok.GrokPattern;
 import org.graylog2.grok.GrokPatternRegistry;
 import org.graylog2.grok.GrokPatternService;
@@ -101,6 +106,7 @@ import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 
 import java.util.Map;
 import java.util.Set;
@@ -110,12 +116,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class FunctionsSnippetsTest extends BaseParserTest {
 
     public static final DateTime GRAYLOG_EPOCH = DateTime.parse("2010-07-30T16:03:25Z");
+    private static final EventBus eventBus = new EventBus();
+    private static StreamCacheService streamCacheService;
 
     @BeforeClass
     public static void registerFunctions() {
@@ -142,9 +151,24 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         when(stream.isPaused()).thenReturn(false);
         when(stream.getTitle()).thenReturn("some name");
         when(stream.getId()).thenReturn("id");
-        when(streamService.loadAll()).thenReturn(Lists.newArrayList(stream));
 
-        functions.put(RouteToStream.NAME, new RouteToStream(streamService));
+        final Stream stream2 = mock(Stream.class);
+        when(stream2.isPaused()).thenReturn(false);
+        when(stream2.getTitle()).thenReturn("some name");
+        when(stream2.getId()).thenReturn("id2");
+
+        when(streamService.loadAll()).thenReturn(Lists.newArrayList(stream, stream2));
+        when(streamService.loadAllEnabled()).thenReturn(Lists.newArrayList(stream, stream2));
+        try {
+            when(streamService.load(anyString())).thenThrow(new NotFoundException());
+            when(streamService.load(ArgumentMatchers.eq("id"))).thenReturn(stream);
+            when(streamService.load(ArgumentMatchers.eq("id2"))).thenReturn(stream2);
+        } catch (NotFoundException ignored) {
+            // oh well, checked exceptions <3
+        }
+        streamCacheService = new StreamCacheService(eventBus, streamService, null);
+        streamCacheService.startAsync().awaitRunning();
+        functions.put(RouteToStream.NAME, new RouteToStream(streamCacheService));
 
         // input related functions
         // TODO needs mock
@@ -653,5 +677,25 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
         }
+    }
+
+    @Test
+    public void routeToStream() {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = evaluateRule(rule);
+
+        assertThat(message).isNotNull();
+        assertThat(message.getStreams()).isNotEmpty();
+        assertThat(message.getStreams().size()).isEqualTo(1);
+        final Stream stream = Iterables.getOnlyElement(message.getStreams());
+        assertThat(stream.getId()).isEqualTo("id2");
+
+        streamCacheService.updateStreams(ImmutableSet.of("id"));
+
+        final Message message2 = evaluateRule(rule);
+        assertThat(message2).isNotNull();
+        assertThat(message2.getStreams().size()).isEqualTo(1);
+        final Stream stream2 = Iterables.getOnlyElement(message2.getStreams());
+        assertThat(stream2.getId()).isEqualTo("id");
     }
 }

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/messages/StreamCacheServiceTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/messages/StreamCacheServiceTest.java
@@ -1,0 +1,25 @@
+package org.graylog.plugins.pipelineprocessor.functions.messages;
+
+import com.google.common.eventbus.EventBus;
+
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.streams.StreamService;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class StreamCacheServiceTest {
+    @Test
+    public void getByName() throws Exception {
+        final StreamCacheService streamCacheService = new StreamCacheService(new EventBus(), mock(StreamService.class), Executors.newSingleThreadScheduledExecutor());
+
+        // make sure getByName always returns a collection
+        final Collection<Stream> streams = streamCacheService.getByName("nonexisting");
+        assertThat(streams).isNotNull().isEmpty();
+    }
+
+}

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/routeToStream.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/routeToStream.txt
@@ -1,0 +1,5 @@
+rule "stream routing"
+when true
+then
+    route_to_stream(name: "some name");
+end


### PR DESCRIPTION
cache stream ids and titles to avoid heavy database traffic during function evaluation

fixes #101