### PR TITLE
Update to react-bootstrap 0.30

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,4 +100,5 @@ buildNumber.properties
 node_modules
 node
 build
+plugin/cache
 

--- a/plugin/src/web/pipelines/PipelineConnectionsForm.jsx
+++ b/plugin/src/web/pipelines/PipelineConnectionsForm.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { Input, Button } from 'react-bootstrap';
+import { Button, ControlLabel, FormGroup, HelpBlock } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import naturalSort from 'javascript-natural-sort';
 
@@ -87,13 +87,14 @@ const PipelineConnectionsForm = React.createClass({
         <BootstrapModalForm ref="modal" title={<span>Edit connections for <em>{this.props.pipeline.title}</em></span>}
                             onSubmitForm={this._save} onCancel={this._resetForm} submitButtonText="Save">
           <fieldset>
-            <Input label="Streams"
-                   help={streamsHelp}>
+            <FormGroup id="streamsConnections">
+              <ControlLabel>Streams</ControlLabel>
               <SelectableList options={this._getFormattedStreams(this._getFilteredStreams(this.props.streams))}
                               onChange={this._onStreamsChange}
                               selectedOptionsType="object"
                               selectedOptions={this.state.connectedStreams} />
-            </Input>
+              <HelpBlock>{streamsHelp}</HelpBlock>
+            </FormGroup>
           </fieldset>
         </BootstrapModalForm>
       </span>

--- a/plugin/src/web/pipelines/PipelineForm.jsx
+++ b/plugin/src/web/pipelines/PipelineForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Row, Col, Input, Button } from 'react-bootstrap';
+import { Row, Col, Button } from 'react-bootstrap';
 
-import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
 import ObjectUtils from 'util/ObjectUtils';
 import FormsUtils from 'util/FormsUtils';
 

--- a/plugin/src/web/pipelines/StageForm.jsx
+++ b/plugin/src/web/pipelines/StageForm.jsx
@@ -1,10 +1,10 @@
 import React, { PropTypes } from 'react';
 import Reflux from 'reflux';
-import { Input, Button } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
 import { SelectableList } from 'components/common';
-import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
 import ObjectUtils from 'util/ObjectUtils';
 import FormsUtils from 'util/FormsUtils';
 

--- a/plugin/src/web/rules/RuleForm.jsx
+++ b/plugin/src/web/rules/RuleForm.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormControls, Row, Col, Button, Input } from 'react-bootstrap';
+import { Button, Col, ControlLabel, FormControl, FormGroup, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
 import AceEditor from 'react-ace';
@@ -8,6 +8,7 @@ import brace from 'brace';
 import 'brace/mode/text';
 import 'brace/theme/chrome';
 
+import { Input } from 'components/bootstrap';
 import Routes from 'routing/Routes';
 
 import RuleFormStyle from './RuleForm.css';
@@ -156,9 +157,10 @@ const RuleForm = React.createClass({
     return (
       <form ref="form" onSubmit={this._submit}>
         <fieldset>
-          <FormControls.Static type="static"
-                               label="Title"
-                               value="You can set the rule title in the rule source. See the quick reference for more information." />
+          <FormGroup id="ruleTitleInformation">
+            <ControlLabel>Title</ControlLabel>
+            <FormControl.Static>You can set the rule title in the rule source. See the quick reference for more information.</FormControl.Static>
+          </FormGroup>
 
           <Input type="textarea"
                  id={this._getId('description')}

--- a/plugin/src/web/rules/RuleHelper.jsx
+++ b/plugin/src/web/rules/RuleHelper.jsx
@@ -126,7 +126,7 @@ end`,
         </Row>
         <Row className="row-sm">
           <Col md={12}>
-            <Tabs defaultActiveKey={1} animation={false}>
+            <Tabs id="functionsHelper" defaultActiveKey={1} animation={false}>
               <Tab eventKey={1} title="Functions">
                 <p className={RuleHelperStyle.marginTab}>
                   This is a list of all available functions in pipeline rules. Click on a row to see more information

--- a/plugin/src/web/simulator/ProcessorSimulator.jsx
+++ b/plugin/src/web/simulator/ProcessorSimulator.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Col, Input, Panel, Row } from 'react-bootstrap';
+import { Col, ControlLabel, FormGroup, HelpBlock, Panel, Row } from 'react-bootstrap';
 import naturalSort from 'javascript-natural-sort';
 import { LinkContainer } from 'react-router-bootstrap';
 
@@ -100,11 +100,12 @@ const ProcessorSimulator = React.createClass({
             </p>
             <Row className="row-sm">
               <Col md={7}>
-                <Input label="Stream"
-                       help={streamHelp}>
+                <FormGroup id="streamSelectorSimulation">
+                  <ControlLabel>Stream</ControlLabel>
                   <Select options={this._getFormattedStreams(this.props.streams)}
                           onValueChange={this._onStreamSelect} value={this.state.stream.id} clearable={false} />
-                </Input>
+                  <HelpBlock>{streamHelp}</HelpBlock>
+                </FormGroup>
               </Col>
             </Row>
             <RawMessageLoader onMessageLoaded={this._onMessageLoad} inputIdSelector />

--- a/plugin/src/web/simulator/SimulationResults.jsx
+++ b/plugin/src/web/simulator/SimulationResults.jsx
@@ -41,7 +41,7 @@ const SimulationResults = React.createClass({
 
   style: require('!style/useable!css!./SimulationResults.css'),
 
-  _changeViewOptions(_, eventKey) {
+  _changeViewOptions(eventKey) {
     const selectedOption = Object.keys(this.VIEW_OPTIONS).find(key => this.VIEW_OPTIONS[key] === eventKey);
     this.setState({ viewOption: this.VIEW_OPTIONS[selectedOption] });
   },


### PR DESCRIPTION
In this case we needed to adapt:

- `onSelect` handler signature
- Add ID to `Tabs` component used in the edit rules page
- Use new inputs API, mostly by using the Input adaptor

Needs to be built against https://github.com/Graylog2/graylog2-server/pull/3598