### PR TITLE
Use uppercase timezone in TimezoneAwareFunction and fix default value

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/TimezoneAwareFunction.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/TimezoneAwareFunction.java
@@ -40,7 +40,7 @@ public abstract class TimezoneAwareFunction extends AbstractFunction<DateTime> {
     protected TimezoneAwareFunction() {
         timeZoneParam = ParameterDescriptor
                 .string(TIMEZONE, DateTimeZone.class)
-                .transform(id -> DateTimeZone.forID(UPPER_ZONE_MAP.get(id)))
+                .transform(id -> DateTimeZone.forID(UPPER_ZONE_MAP.getOrDefault(id.toUpperCase(Locale.ENGLISH), "UTC")))
                 .optional()
                 .description("The timezone to apply to the date, defaults to UTC")
                 .build();

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/timezones.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/timezones.txt
@@ -5,7 +5,12 @@ when
   now("CET") == now("UTC") &&
   now("utc") == now("UTC") &&
   now("Europe/Moscow") == now("europe/moscow") &&
-  now("europe/MoSCOw") == now("msk")
+  now("europe/MoSCOw") == now("msk") &&
+  to_string(now("europe/MoSCOw").zone) == "Europe/Moscow" &&
+  to_string(now("cet").zone) == "CET" &&
+  to_string(now("Etc/gmt-14").zone) == "Etc/GMT-14" &&
+  to_string(now("").zone) == "UTC" &&
+  to_string(now("invalid-timezone").zone) == "UTC"
 then
   trigger_test();
 end


### PR DESCRIPTION
This PR makes sure that the user-provided timezone in `TimezoneAwareFunction` is being looked up in uppercase and that the default timezone is "UTC".
Otherwise the timezone might not be found in the lookup table and the `timezone` parameter would be interpreted as the local system's timezone.

Fixes #168