### PR TITLE
Smaller UI and UX changes

### DIFF
--- a/plugin/src/web/pipelines/Pipeline.css
+++ b/plugin/src/web/pipelines/Pipeline.css
@@ -22,3 +22,7 @@ dl.pipeline-dl > dd {
 .description-margin-top {
     margin-top: 5px;
 }
+
+.pipeline-no-connections-warning {
+    margin-bottom: 13px;
+}

--- a/plugin/src/web/pipelines/Pipeline.jsx
+++ b/plugin/src/web/pipelines/Pipeline.jsx
@@ -87,10 +87,6 @@ const Pipeline = React.createClass({
         <Row className="row-sm row-margin-top">
           <Col md={12}>
             <div className="pull-right">
-              <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES_SIMULATE')}>
-                <Button bsStyle="info">Simulate processing</Button>
-              </LinkContainer>
-              &nbsp;
               <PipelineConnectionsForm pipeline={pipeline} connections={this.props.connections}
                                        streams={this.props.streams} save={this.props.onConnectionsChange} />
             </div>

--- a/plugin/src/web/pipelines/Pipeline.jsx
+++ b/plugin/src/web/pipelines/Pipeline.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Row, Col } from 'react-bootstrap';
+import { Button, Row, Col, Alert } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
 import { EntityList, Pluralize } from 'components/common';
@@ -30,6 +30,17 @@ const Pipeline = React.createClass({
   },
 
   style: require('!style/useable!css!./Pipeline.css'),
+
+  _connections_warning() {
+    if(this.props.connections.length == 0) {
+      return (
+          <Alert bsStyle="danger" className="pipeline-no-connections-warning">
+            This pipeline is currently not connected to any streams. You have to connect a pipeline to at least one
+            stream to make it process messages.
+          </Alert>
+      );
+    }
+  },
 
   _saveStage(stage, callback) {
     const newStages = this.props.pipeline.stages.slice();
@@ -83,6 +94,7 @@ const Pipeline = React.createClass({
 
     return (
       <div>
+        {this._connections_warning()}
         <PipelineDetails pipeline={pipeline} onChange={this.props.onPipelineChange} />
         <Row className="row-sm row-margin-top">
           <Col md={12}>

--- a/plugin/src/web/pipelines/Pipeline.jsx
+++ b/plugin/src/web/pipelines/Pipeline.jsx
@@ -36,7 +36,8 @@ const Pipeline = React.createClass({
       return (
           <Alert bsStyle="danger" className="pipeline-no-connections-warning">
             This pipeline is currently not connected to any streams. You have to connect a pipeline to at least one
-            stream to make it process messages.
+            stream to make it process incoming messages. Note that this is not required if you intend to use this
+            pipeline only for search result transformation using decorators.
           </Alert>
       );
     }

--- a/plugin/src/web/pipelines/PipelineConnectionsForm.jsx
+++ b/plugin/src/web/pipelines/PipelineConnectionsForm.jsx
@@ -74,7 +74,7 @@ const PipelineConnectionsForm = React.createClass({
   render() {
     const streamsHelp = (
       <span>
-        Select the streams you want to connect this pipeline, or create one in the{' '}
+        Select the streams you want to connect to this pipeline, or create one in the{' '}
         <LinkContainer to={Routes.STREAMS}><a>Streams page</a></LinkContainer>.
       </span>
     );

--- a/plugin/src/web/pipelines/PipelineDetailsPage.jsx
+++ b/plugin/src/web/pipelines/PipelineDetailsPage.jsx
@@ -134,11 +134,15 @@ const PipelineDetailsPage = React.createClass({
 
             <span>
               <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES')}>
-                <Button bsStyle="info">Manage pipelines</Button>
+                <Button bsStyle="info active">Manage pipelines</Button>
               </LinkContainer>
-              {' '}
+              &nbsp;
               <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES_RULES')}>
                 <Button bsStyle="info">Manage rules</Button>
+              </LinkContainer>
+              &nbsp;
+              <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES_SIMULATE')}>
+                <Button bsStyle="info">Simulator</Button>
               </LinkContainer>
             </span>
           </PageHeader>

--- a/plugin/src/web/pipelines/PipelinesOverviewPage.jsx
+++ b/plugin/src/web/pipelines/PipelinesOverviewPage.jsx
@@ -24,12 +24,16 @@ const PipelinesOverviewPage = React.createClass({
             </span>
 
             <span>
-              <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES_SIMULATE')}>
-                <Button bsStyle="info">Simulate processing</Button>
+              <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES')}>
+                <Button bsStyle="info active">Manage pipelines</Button>
               </LinkContainer>
               &nbsp;
               <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES_RULES')}>
                 <Button bsStyle="info">Manage rules</Button>
+              </LinkContainer>
+              &nbsp;
+              <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES_SIMULATE')}>
+                <Button bsStyle="info">Simulator</Button>
               </LinkContainer>
             </span>
           </PageHeader>

--- a/plugin/src/web/rules/Rule.jsx
+++ b/plugin/src/web/rules/Rule.jsx
@@ -45,14 +45,18 @@ const Rule = React.createClass({
           </span>
 
           <span>
-            <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES')}>
-              <Button bsStyle="info">Manage pipelines</Button>
-            </LinkContainer>
+              <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES')}>
+                <Button bsStyle="info">Manage pipelines</Button>
+              </LinkContainer>
             &nbsp;
             <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES_RULES')}>
-              <Button bsStyle="info">Manage rules</Button>
-            </LinkContainer>
-          </span>
+                <Button bsStyle="info active">Manage rules</Button>
+              </LinkContainer>
+            &nbsp;
+            <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES_SIMULATE')}>
+                <Button bsStyle="info">Simulator</Button>
+              </LinkContainer>
+            </span>
         </PageHeader>
 
         <Row className="content">

--- a/plugin/src/web/rules/RulesPage.jsx
+++ b/plugin/src/web/rules/RulesPage.jsx
@@ -42,6 +42,14 @@ const RulesPage = React.createClass({
               <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES')}>
                 <Button bsStyle="info">Manage pipelines</Button>
               </LinkContainer>
+              &nbsp;
+              <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES_RULES')}>
+                <Button bsStyle="info active">Manage rules</Button>
+              </LinkContainer>
+              &nbsp;
+              <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES_SIMULATE')}>
+                <Button bsStyle="info">Simulator</Button>
+              </LinkContainer>
             </span>
           </PageHeader>
 

--- a/plugin/src/web/simulator/SimulatorPage.jsx
+++ b/plugin/src/web/simulator/SimulatorPage.jsx
@@ -57,6 +57,10 @@ const SimulatorPage = React.createClass({
               <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES_RULES')}>
                 <Button bsStyle="info">Manage rules</Button>
               </LinkContainer>
+              &nbsp;
+              <LinkContainer to={Routes.pluginRoute('SYSTEM_PIPELINES_SIMULATE')}>
+                <Button bsStyle="info active">Simulator</Button>
+              </LinkContainer>
             </span>
           </PageHeader>
 


### PR DESCRIPTION
Like in other parts of the web interface, I changed the way the buttons are used to navigate in the top part of the pages. The way they were changing from page to page made following the current position in the navigation really hard and jumping back almost impossible. We are now always using the same button composition and the current page or parent page is highlighted as `active`. 

![pipelinesnav](https://cloud.githubusercontent.com/assets/35022/26505478/3cd3577e-4249-11e7-95fa-99489d4218d7.gif)

I added a prominent warning in case a pipeline is not connected to a stream. I noticed quite a few users who got stuck at this part of setting up pipelines because it is not immediately clear that you have to connect a pipeline to a stream and the current small warning is hard to notice.

<img width="1490" alt="screen shot 2017-05-26 at 6 28 49 pm" src="https://cloud.githubusercontent.com/assets/35022/26505525/6cec19c8-4249-11e7-906b-a24c41325ec1.png">

