### PR TITLE
New function: debug()

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -40,6 +40,7 @@ import org.graylog.plugins.pipelineprocessor.functions.dates.periods.PeriodParse
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Seconds;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Weeks;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Years;
+import org.graylog.plugins.pipelineprocessor.functions.debug.Debug;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32C;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.MD5;
@@ -177,6 +178,9 @@ public class ProcessorFunctionsModule extends PluginModule {
         // Lookup tables
         addMessageProcessorFunction(Lookup.NAME, Lookup.class);
         addMessageProcessorFunction(LookupValue.NAME, LookupValue.class);
+
+        // Debug
+        addMessageProcessorFunction(Debug.NAME, Debug.class);
     }
 
     protected void addMessageProcessorFunction(String name, Class<? extends Function<?>> functionClass) {

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/debug/Debug.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/debug/Debug.java
@@ -1,0 +1,45 @@
+package org.graylog.plugins.pipelineprocessor.functions.debug;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class Debug extends AbstractFunction<Void> {
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    public static final String NAME = "debug";
+
+    Debug() {
+        valueParam = ParameterDescriptor.object("value").description("The value to print in the graylog-server log.").build();
+    }
+
+    @Override
+    public Void evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+
+        if(value == null) {
+            log.info("PIPELINE DEBUG: Passed value is NULL.");
+        } else {
+            log.info("PIPELINE DEBUG: {}", value.toString());
+        }
+
+        return null;
+    }
+
+    @Override
+    public FunctionDescriptor<Void> descriptor() {
+        return FunctionDescriptor.<Void>builder()
+                .name(NAME)
+                .returnType(Void.class)
+                .params(of(valueParam) )
+                .description("Print any passed value as string in the graylog-server log. Note that this will only appear in the " +
+                        "log of the graylog-server node that is processing the message you are trying to debug.")
+                .build();
+    }
+
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/debug/Debug.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/debug/Debug.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.pipelineprocessor.functions.debug;
 
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;


### PR DESCRIPTION
Added a new function that will log the string representation of any value that has been passed to it. I just found this immensely helpful when working with a lookup table result.

Example output:

```
2017-05-29 17:18:54,271 INFO : org.graylog.plugins.pipelineprocessor.ast.functions.Function - PIPELINE DEBUG: {city=com.maxmind.geoip2.record.City [ {"geoname_id":5375480,"names":{"de":"Mountain View","ru":"Маунтин-Вью","ja":"マウンテンビュー","en":"Mountain View","fr":"Mountain View","zh-CN":"芒廷维尤"}} ], continent=com.maxmind.geoip2.record.Continent [ {"code":"NA","geoname_id":6255149,"names":{"de":"Nordamerika","ru":"Северная Америка","pt-BR":"América do Norte","ja":"北アメリカ","en":"North America","fr":"Amérique du Nord","zh-CN":"北美洲","es":"Norteamérica"}} ], country=com.maxmind.geoip2.record.Country [ {"geoname_id":6252001,"iso_code":"US","names":{"de":"USA","ru":"США","pt-BR":"Estados Unidos","ja":"アメリカ合衆国","en":"United States","fr":"États-Unis","zh-CN":"美国","es":"Estados Unidos"}} ], location=com.maxmind.geoip2.record.Location [ {"accuracy_radius":1000,"latitude":37.386,"longitude":-122.0838,"metro_code":807,"time_zone":"America/Los_Angeles"} ], postal=com.maxmind.geoip2.record.Postal [ {"code":"94035"} ], registered_country=com.maxmind.geoip2.record.Country [ {"geoname_id":6252001,"iso_code":"US","names":{"de":"USA","ru":"США","pt-BR":"Estados Unidos","ja":"アメリカ合衆国","en":"United States","fr":"États-Unis","zh-CN":"美国","es":"Estados Unidos"}} ], represented_country=com.maxmind.geoip2.record.RepresentedCountry [ {} ], subdivisions=[com.maxmind.geoip2.record.Subdivision [ {"geoname_id":5332921,"iso_code":"CA","names":{"de":"Kalifornien","ru":"Калифорния","pt-BR":"Califórnia","ja":"カリフォルニア州","en":"California","fr":"Californie","zh-CN":"加利福尼亚州","es":"California"}} ]], traits=com.maxmind.geoip2.record.Traits [ {"ip_address":"8.8.8.8","is_anonymous_proxy":false,"is_legitimate_proxy":false,"is_satellite_provider":false} ]}
```