### PR TITLE
Add various Base encoding functions

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -20,7 +20,6 @@ import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
-
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.BooleanConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.DoubleConversion;
@@ -41,6 +40,16 @@ import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Seconds;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Weeks;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Years;
 import org.graylog.plugins.pipelineprocessor.functions.debug.Debug;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base16Decode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base16Encode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base32Decode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base32Encode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base32HumanDecode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base32HumanEncode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base64Decode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base64Encode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base64UrlDecode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base64UrlEncode;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32C;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.MD5;
@@ -157,6 +166,16 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(SHA1.NAME, SHA1.class);
         addMessageProcessorFunction(SHA256.NAME, SHA256.class);
         addMessageProcessorFunction(SHA512.NAME, SHA512.class);
+
+        // encoding
+        addMessageProcessorFunction(Base16Encode.NAME, Base16Encode.class);
+        addMessageProcessorFunction(Base16Decode.NAME, Base16Decode.class);
+        addMessageProcessorFunction(Base32Encode.NAME, Base32Encode.class);
+        addMessageProcessorFunction(Base32Decode.NAME, Base32Decode.class);
+        addMessageProcessorFunction(Base32HumanEncode.NAME, Base32HumanEncode.class);
+        addMessageProcessorFunction(Base32HumanDecode.NAME, Base32HumanDecode.class);
+        addMessageProcessorFunction(Base64UrlEncode.NAME, Base64UrlEncode.class);
+        addMessageProcessorFunction(Base64UrlDecode.NAME, Base64UrlDecode.class);
 
         // ip handling
         addMessageProcessorFunction(CidrMatch.NAME, CidrMatch.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base16Decode.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base16Decode.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.encoding;
+
+import com.google.common.io.BaseEncoding;
+
+import java.nio.charset.StandardCharsets;
+
+public class Base16Decode extends BaseEncodingSingleArgStringFunction {
+    public static final String NAME = "base16_decode";
+    private static final String ENCODING_NAME = "base16";
+
+    @Override
+    protected String getEncodedValue(String value, boolean omitPadding) {
+        BaseEncoding encoding = BaseEncoding.base16();
+        encoding = omitPadding ? encoding.omitPadding() : encoding;
+
+        return new String(encoding.decode(value), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    protected String getEncodingName() {
+        return ENCODING_NAME;
+    }
+
+    protected String getName() {
+        return NAME;
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base16Encode.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base16Encode.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.encoding;
+
+import com.google.common.io.BaseEncoding;
+
+import java.nio.charset.StandardCharsets;
+
+public class Base16Encode extends BaseEncodingSingleArgStringFunction {
+    public static final String NAME = "base16_encode";
+    private static final String ENCODING_NAME = "base16";
+
+    @Override
+    protected String getEncodedValue(String value, boolean omitPadding) {
+        BaseEncoding encoding = BaseEncoding.base16();
+        encoding = omitPadding ? encoding.omitPadding() : encoding;
+
+        return encoding.encode(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    protected String getEncodingName() {
+        return ENCODING_NAME;
+    }
+
+    protected String getName() {
+        return NAME;
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base32Decode.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base32Decode.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.encoding;
+
+import com.google.common.io.BaseEncoding;
+
+import java.nio.charset.StandardCharsets;
+
+public class Base32Decode extends BaseEncodingSingleArgStringFunction {
+    public static final String NAME = "base32_decode";
+    private static final String ENCODING_NAME = "base32";
+
+    @Override
+    protected String getEncodedValue(String value, boolean omitPadding) {
+        BaseEncoding encoding = BaseEncoding.base32Hex();
+        encoding = omitPadding ? encoding.omitPadding() : encoding;
+
+        return new String(encoding.decode(value), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    protected String getEncodingName() {
+        return ENCODING_NAME;
+    }
+
+    protected String getName() {
+        return NAME;
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base32Encode.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base32Encode.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.encoding;
+
+import com.google.common.io.BaseEncoding;
+
+import java.nio.charset.StandardCharsets;
+
+public class Base32Encode extends BaseEncodingSingleArgStringFunction {
+    public static final String NAME = "base32_encode";
+    private static final String ENCODING_NAME = "base32";
+
+    @Override
+    protected String getEncodedValue(String value, boolean omitPadding) {
+        BaseEncoding encoding = BaseEncoding.base32Hex();
+        encoding = omitPadding ? encoding.omitPadding() : encoding;
+
+        return encoding.encode(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    protected String getEncodingName() {
+        return ENCODING_NAME;
+    }
+
+    protected String getName() {
+        return NAME;
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base32HumanDecode.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base32HumanDecode.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.encoding;
+
+import com.google.common.io.BaseEncoding;
+
+import java.nio.charset.StandardCharsets;
+
+public class Base32HumanDecode extends BaseEncodingSingleArgStringFunction {
+    public static final String NAME = "base32human_decode";
+    private static final String ENCODING_NAME = "base32 (human-friendly)";
+
+    @Override
+    protected String getEncodedValue(String value, boolean omitPadding) {
+        BaseEncoding encoding = BaseEncoding.base32();
+        encoding = omitPadding ? encoding.omitPadding() : encoding;
+
+        return new String(encoding.decode(value), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    protected String getEncodingName() {
+        return ENCODING_NAME;
+    }
+
+    protected String getName() {
+        return NAME;
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base32HumanEncode.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base32HumanEncode.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.encoding;
+
+import com.google.common.io.BaseEncoding;
+
+import java.nio.charset.StandardCharsets;
+
+public class Base32HumanEncode extends BaseEncodingSingleArgStringFunction {
+    public static final String NAME = "base32human_encode";
+    private static final String ENCODING_NAME = "base32 (human-friendly)";
+
+    @Override
+    protected String getEncodedValue(String value, boolean omitPadding) {
+        BaseEncoding encoding = BaseEncoding.base32();
+        encoding = omitPadding ? encoding.omitPadding() : encoding;
+
+        return encoding.encode(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    protected String getEncodingName() {
+        return ENCODING_NAME;
+    }
+
+    protected String getName() {
+        return NAME;
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base64Decode.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base64Decode.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.encoding;
+
+import com.google.common.io.BaseEncoding;
+
+import java.nio.charset.StandardCharsets;
+
+public class Base64Decode extends BaseEncodingSingleArgStringFunction {
+    public static final String NAME = "base64_decode";
+    private static final String ENCODING_NAME = "base64";
+
+    @Override
+    protected String getEncodedValue(String value, boolean omitPadding) {
+        BaseEncoding encoding = BaseEncoding.base64();
+        encoding = omitPadding ? encoding.omitPadding() : encoding;
+
+        return new String(encoding.decode(value), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    protected String getEncodingName() {
+        return ENCODING_NAME;
+    }
+
+    protected String getName() {
+        return NAME;
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base64Encode.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base64Encode.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.encoding;
+
+import com.google.common.io.BaseEncoding;
+
+import java.nio.charset.StandardCharsets;
+
+public class Base64Encode extends BaseEncodingSingleArgStringFunction {
+    public static final String NAME = "base64_encode";
+    private static final String ENCODING_NAME = "base64";
+
+    @Override
+    protected String getEncodedValue(String value, boolean omitPadding) {
+        BaseEncoding encoding = BaseEncoding.base64();
+        encoding = omitPadding ? encoding.omitPadding() : encoding;
+
+        return encoding.encode(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    protected String getEncodingName() {
+        return ENCODING_NAME;
+    }
+
+    protected String getName() {
+        return NAME;
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base64UrlDecode.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base64UrlDecode.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.encoding;
+
+import com.google.common.io.BaseEncoding;
+
+import java.nio.charset.StandardCharsets;
+
+public class Base64UrlDecode extends BaseEncodingSingleArgStringFunction {
+    public static final String NAME = "base64url_decode";
+    private static final String ENCODING_NAME = "base64 (URL-safe)";
+
+    @Override
+    protected String getEncodedValue(String value, boolean omitPadding) {
+        BaseEncoding encoding = BaseEncoding.base64Url();
+        encoding = omitPadding ? encoding.omitPadding() : encoding;
+
+        return new String(encoding.decode(value), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    protected String getEncodingName() {
+        return ENCODING_NAME;
+    }
+
+    protected String getName() {
+        return NAME;
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base64UrlEncode.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/Base64UrlEncode.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.encoding;
+
+import com.google.common.io.BaseEncoding;
+
+import java.nio.charset.StandardCharsets;
+
+public class Base64UrlEncode extends BaseEncodingSingleArgStringFunction {
+    public static final String NAME = "base64url_encode";
+    private static final String ENCODING_NAME = "base64 (URL-safe)";
+
+    @Override
+    protected String getEncodedValue(String value, boolean omitPadding) {
+        BaseEncoding encoding = BaseEncoding.base64Url();
+        encoding = omitPadding ? encoding.omitPadding() : encoding;
+
+        return encoding.encode(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    protected String getEncodingName() {
+        return ENCODING_NAME;
+    }
+
+    protected String getName() {
+        return NAME;
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/BaseEncodingSingleArgStringFunction.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/encoding/BaseEncodingSingleArgStringFunction.java
@@ -1,0 +1,65 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.encoding;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.Locale;
+
+import static com.google.common.collect.ImmutableList.of;
+
+abstract class BaseEncodingSingleArgStringFunction extends AbstractFunction<String> {
+
+    private final ParameterDescriptor<String, String> valueParam;
+    private final ParameterDescriptor<Boolean, Boolean> omitPaddingParam;
+
+    BaseEncodingSingleArgStringFunction() {
+        valueParam = ParameterDescriptor.string("value").description("The value to encode with " + getEncodingName()).build();
+        omitPaddingParam = ParameterDescriptor.bool("omit_padding").optional().description("Omit any padding characters as specified by RFC 4648 section 3.2").build();
+    }
+
+    @Override
+    public String evaluate(FunctionArgs args, EvaluationContext context) {
+        final String value = valueParam.required(args, context);
+        final boolean omitPadding = omitPaddingParam.optional(args, context).orElse(false);
+        return getEncodedValue(value, omitPadding);
+    }
+
+    protected abstract String getEncodedValue(String value, boolean omitPadding);
+
+    protected abstract String getName();
+
+    protected abstract String getEncodingName();
+
+    protected String description() {
+        return getEncodingName() + " encoding/decoding of the string";
+    }
+
+    @Override
+    public FunctionDescriptor<String> descriptor() {
+        return FunctionDescriptor.<String>builder()
+                .name(getName())
+                .returnType(String.class)
+                .params(of(valueParam, omitPaddingParam))
+                .description(description())
+                .build();
+    }
+}

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -16,15 +16,13 @@
  */
 package org.graylog.plugins.pipelineprocessor.functions;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.net.InetAddresses;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.graylog.plugins.pipelineprocessor.BaseParserTest;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
@@ -47,6 +45,16 @@ import org.graylog.plugins.pipelineprocessor.functions.dates.periods.PeriodParse
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Seconds;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Weeks;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Years;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base16Decode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base16Encode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base32Decode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base32Encode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base32HumanDecode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base32HumanEncode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base64Decode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base64Encode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base64UrlDecode;
+import org.graylog.plugins.pipelineprocessor.functions.encoding.Base64UrlEncode;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32C;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.MD5;
@@ -221,6 +229,17 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(SHA256.NAME, new SHA256());
         functions.put(SHA512.NAME, new SHA512());
 
+        functions.put(Base16Encode.NAME, new Base16Encode());
+        functions.put(Base16Decode.NAME, new Base16Decode());
+        functions.put(Base32Encode.NAME, new Base32Encode());
+        functions.put(Base32Decode.NAME, new Base32Decode());
+        functions.put(Base32HumanEncode.NAME, new Base32HumanEncode());
+        functions.put(Base32HumanDecode.NAME, new Base32HumanDecode());
+        functions.put(Base64Encode.NAME, new Base64Encode());
+        functions.put(Base64Decode.NAME, new Base64Decode());
+        functions.put(Base64UrlEncode.NAME, new Base64UrlEncode());
+        functions.put(Base64UrlDecode.NAME, new Base64UrlDecode());
+
         functions.put(IpAddressConversion.NAME, new IpAddressConversion());
         functions.put(CidrMatch.NAME, new CidrMatch());
 
@@ -348,6 +367,14 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
     @Test
     public void digests() {
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+        evaluateRule(rule);
+
+        assertThat(actionsTriggered.get()).isTrue();
+    }
+
+    @Test
+    public void encodings() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         evaluateRule(rule);
 

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/encodings.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/encodings.txt
@@ -1,0 +1,21 @@
+rule "digests"
+when
+    base16_encode(value: "graylog") == "677261796C6F67" &&
+    base16_decode(value: "677261796C6F67") == "graylog" &&
+    base16_encode(value: "graylog", omit_padding: true) == "677261796C6F67" &&
+    base16_decode(value: "677261796C6F67", omit_padding: true) == "graylog" &&
+    base32_encode(value: "graylog") == "CTP62UBCDTJG====" &&
+    base32_decode(value: "CTP62UBCDTJG====") == "graylog" &&
+    base32_encode(value: "graylog", omit_padding: true) == "CTP62UBCDTJG" &&
+    base32_decode(value: "CTP62UBCDTJG", omit_padding: true) == "graylog" &&
+    base32human_encode(value: "graylog") == "M5ZGC6LMN5TQ====" &&
+    base32human_decode(value: "M5ZGC6LMN5TQ====") == "graylog" &&
+    base32human_encode(value: "graylog", omit_padding: true) == "M5ZGC6LMN5TQ" &&
+    base32human_decode(value: "M5ZGC6LMN5TQ", omit_padding: true) == "graylog" &&
+    base64_encode(value: "graylog") == "Z3JheWxvZw==" &&
+    base64_decode(value: "Z3JheWxvZw==") == "graylog" &&
+    base64url_encode(value: "graylog", omit_padding: true) == "Z3JheWxvZw" &&
+    base64url_decode(value: "Z3JheWxvZw", omit_padding: true) == "graylog"
+then
+    trigger_test();
+end


### PR DESCRIPTION
This PR adds various Base encoding functions (Base16, Base32, Base64, and some variants).

In fact, it provides the functionality of Guava's [`BaseEncoding`](https://google.github.io/guava/releases/21.0/api/docs/com/google/common/io/BaseEncoding.html) to the processing pipelines.

This can be useful to transport binary data over the wire in a safe-ish format.

[Discussion from IRC](https://botbot.me/freenode/graylog/msg/87519943/):
```
<joschi> jose_: could you elaborate on the use case, please?
<jose_> so briefly i'm at fastly, we're using a lot of graylog internally (and wrote a blog post series on it). i'm doing a demo next week of our WAF product and using graylog as a log analysis platform for the workshop.
<jose_> as part of our logging we export attack data (from the client) base64 encoded to avoid fouling up log parsers (it's CSV records streamed out)
<jose_> rather than trying to escape all possible screwyness
<jose_> so after it arrives and then extracted using a CSV field split, and before it gets stored, i'd like to un-encode it
<jose_> so i can see it natively in the product
```
