### PR TITLE
Prevent ClassCastException with invalid timestamp in clone_message()

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/CloneMessage.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/CloneMessage.java
@@ -25,10 +25,14 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
 import org.graylog2.plugin.Message;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.type;
 
 public class CloneMessage extends AbstractFunction<Message> {
+    private static final Logger LOG = LoggerFactory.getLogger(CloneMessage.class);
+
     public static final String NAME = "clone_message";
 
     private final ParameterDescriptor<Message, Message> messageParam;
@@ -47,6 +51,9 @@ public class CloneMessage extends AbstractFunction<Message> {
             clonedMessage = new Message(currentMessage.getMessage(), currentMessage.getSource(), currentMessage.getTimestamp());
             clonedMessage.addFields(currentMessage.getFields());
         } else {
+            LOG.warn("Invalid timestamp <{}> (type: {}) in message <{}>. Using current time instead.",
+                    tsField, tsField.getClass().getCanonicalName(), currentMessage.getId());
+
             final DateTime now = DateTime.now(DateTimeZone.UTC);
             clonedMessage = new Message(currentMessage.getMessage(), currentMessage.getSource(), now);
             clonedMessage.addFields(currentMessage.getFields());

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/CloneMessage.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/CloneMessage.java
@@ -60,7 +60,7 @@ public class CloneMessage extends AbstractFunction<Message> {
 
             // Message#addFields() overwrites the "timestamp" field.
             clonedMessage.addField("timestamp", now);
-            clonedMessage.addField("_original_timestamp", String.valueOf(tsField));
+            clonedMessage.addField("gl2_original_timestamp", String.valueOf(tsField));
         }
 
         clonedMessage.addStreams(currentMessage.getStreams());

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/CloneMessage.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/CloneMessage.java
@@ -53,7 +53,7 @@ public class CloneMessage extends AbstractFunction<Message> {
 
             // Message#addFields() overwrites the "timestamp" field.
             clonedMessage.addField("timestamp", now);
-            clonedMessage.addField("_original_timestamp", tsField);
+            clonedMessage.addField("_original_timestamp", String.valueOf(tsField));
         }
 
         clonedMessage.addStreams(currentMessage.getStreams());

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -479,6 +479,27 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
+    public void clonedMessageWithInvalidTimestamp() {
+        final Message message = new Message("test", "test", Tools.nowUTC());
+        message.addField("timestamp", "foobar");
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final EvaluationContext context = contextForRuleEval(rule, message);
+
+        final Message origMessage = context.currentMessage();
+        final Message clonedMessage = Iterables.get(context.createdMessages(), 0);
+
+        assertThat(origMessage).isNotEqualTo(clonedMessage);
+        assertThat(origMessage.getField("timestamp")).isNotInstanceOf(DateTime.class);
+
+        assertThat(clonedMessage).isNotNull();
+        assertThat(clonedMessage.getMessage()).isEqualTo(origMessage.getMessage());
+        assertThat(clonedMessage.getSource()).isEqualTo(origMessage.getSource());
+        assertThat(clonedMessage.getStreams()).isEqualTo(origMessage.getStreams());
+        assertThat(clonedMessage.getTimestamp()).isNotNull();
+        assertThat(clonedMessage.getField("_original_timestamp")).isEqualTo(origMessage.getField("timestamp"));
+    }
+
+    @Test
     public void grok() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = evaluateRule(rule);

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -496,7 +496,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(clonedMessage.getSource()).isEqualTo(origMessage.getSource());
         assertThat(clonedMessage.getStreams()).isEqualTo(origMessage.getStreams());
         assertThat(clonedMessage.getTimestamp()).isNotNull();
-        assertThat(clonedMessage.getField("_original_timestamp")).isEqualTo(origMessage.getField("timestamp"));
+        assertThat(clonedMessage.getField("gl2_original_timestamp")).isEqualTo(origMessage.getField("timestamp"));
     }
 
     @Test

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/clonedMessageWithInvalidTimestamp.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/clonedMessageWithInvalidTimestamp.txt
@@ -1,0 +1,5 @@
+rule "operate on cloned message"
+when true
+then
+  let cloned = clone_message();
+end


### PR DESCRIPTION
If the "timestamp" field of a message is invalid, `clone_message()` will fail with a `ClassCastException` because `Message#getTimestamp()` tries to cast this field to a `DateTime` object.

With the changes in this commit, the type of the "timestamp" field will be checked before accessing it and if it is invalid (i. e. not a `DateTime` object), the current date and time will be used and the original content will be stored in the "_original_timestamp" field of the new message.

Fixes Graylog2/graylog2-server#3880