### PR TITLE
Fix handling of "match all"/"match either"

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
@@ -147,7 +147,7 @@ public class ConfigurationStateUpdater {
         }
         ImmutableSetMultimap<String, Pipeline> streamPipelineConnections = ImmutableSetMultimap.copyOf(connections);
 
-        final PipelineInterpreter.State newState = stateFactory.newState(currentPipelines, streamPipelineConnections, commonClassLoader);
+        final PipelineInterpreter.State newState = stateFactory.newState(currentPipelines, streamPipelineConnections);
         latestState.set(newState);
         return newState;
     }

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -16,13 +16,13 @@
  */
 package org.graylog.plugins.pipelineprocessor.processors;
 
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
-
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricRegistry;
-
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
@@ -41,6 +41,7 @@ import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineStreamCon
 import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbRuleService;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
+import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog.plugins.pipelineprocessor.parser.PipelineRuleParser;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
@@ -52,12 +53,12 @@ import org.graylog2.shared.journal.Journal;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.concurrent.Executors;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static com.google.common.collect.Sets.newHashSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog2.plugin.streams.Stream.DEFAULT_STREAM_ID;
 import static org.junit.Assert.assertEquals;
@@ -65,6 +66,22 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class PipelineInterpreterTest {
+    private static final RuleDao RULE_TRUE = RuleDao.create("true", "true", "true",
+            "rule \"true\"\n" +
+                    "when true\n" +
+                    "then\n" +
+                    "end", null, null);
+    private static final RuleDao RULE_FALSE = RuleDao.create("false", "false", "false",
+            "rule \"false\"\n" +
+                    "when false\n" +
+                    "then\n" +
+                    "end", null, null);
+    private static final RuleDao RULE_ADD_FOOBAR = RuleDao.create("add_foobar", "add_foobar", "add_foobar",
+            "rule \"add_foobar\"\n" +
+                    "when true\n" +
+                    "then\n" +
+                    "  set_field(\"foobar\", \"covfefe\");\n" +
+                    "end", null, null);
 
     @Test
     public void testCreateMessage() {
@@ -84,7 +101,7 @@ public class PipelineInterpreterTest {
 
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("cde", "title", "description",
+                PipelineDao.create("p1", "title", "description",
                         "pipeline \"pipeline\"\n" +
                                 "stage 0 match all\n" +
                                 "    rule \"creates message\";\n" +
@@ -93,18 +110,145 @@ public class PipelineInterpreterTest {
                         null)
         ));
 
-        final PipelineStreamConnectionsService pipelineStreamConnectionsService = mock(
-                MongoDbPipelineStreamConnectionsService.class);
-        final PipelineConnections pipelineConnections = PipelineConnections.create(null,
-                DEFAULT_STREAM_ID,
-                newHashSet("cde"));
-        when(pipelineStreamConnectionsService.loadAll()).thenReturn(
-                newHashSet(pipelineConnections)
-        );
+        final Map<String, Function<?>> functions = ImmutableMap.of(
+                CreateMessage.NAME, new CreateMessage(),
+                StringConversion.NAME, new StringConversion());
 
-        final Map<String, Function<?>> functions = Maps.newHashMap();
-        functions.put(CreateMessage.NAME, new CreateMessage());
-        functions.put(StringConversion.NAME, new StringConversion());
+        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, functions);
+
+        Message msg = messageInDefaultStream("original message", "test");
+        final Messages processed = interpreter.process(msg);
+
+        final Message[] messages = Iterables.toArray(processed, Message.class);
+        assertEquals(2, messages.length);
+    }
+
+    @Test
+    public void testMatchAllContinuesIfAllRulesMatched() {
+        final RuleService ruleService = mock(MongoDbRuleService.class);
+        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RULE_TRUE, RULE_FALSE, RULE_ADD_FOOBAR));
+
+        final PipelineService pipelineService = mock(MongoDbPipelineService.class);
+        when(pipelineService.loadAll()).thenReturn(Collections.singleton(
+                PipelineDao.create("p1", "title", "description",
+                        "pipeline \"pipeline\"\n" +
+                                "stage 0 match all\n" +
+                                "    rule \"true\";\n" +
+                                "stage 1 match either\n" +
+                                "    rule \"add_foobar\";\n" +
+                                "end\n",
+                        Tools.nowUTC(),
+                        null)
+        ));
+
+        final Map<String, Function<?>> functions = ImmutableMap.of(SetField.NAME, new SetField());
+        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, functions);
+
+        final Messages processed = interpreter.process(messageInDefaultStream("message", "test"));
+
+        final List<Message> messages = ImmutableList.copyOf(processed);
+        assertThat(messages).hasSize(1);
+
+        final Message actualMessage = messages.get(0);
+        assertThat(actualMessage.getFieldAs(String.class, "foobar")).isEqualTo("covfefe");
+    }
+
+    @Test
+    public void testMatchAllDoesNotContinueIfNotAllRulesMatched() {
+        final RuleService ruleService = mock(MongoDbRuleService.class);
+        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RULE_TRUE, RULE_FALSE, RULE_ADD_FOOBAR));
+
+        final PipelineService pipelineService = mock(MongoDbPipelineService.class);
+        when(pipelineService.loadAll()).thenReturn(Collections.singleton(
+                PipelineDao.create("p1", "title", "description",
+                        "pipeline \"pipeline\"\n" +
+                                "stage 0 match all\n" +
+                                "    rule \"true\";\n" +
+                                "    rule \"false\";\n" +
+                                "stage 1 match either\n" +
+                                "    rule \"add_foobar\";\n" +
+                                "end\n",
+                        Tools.nowUTC(),
+                        null)
+        ));
+
+        final Map<String, Function<?>> functions = ImmutableMap.of(SetField.NAME, new SetField());
+        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, functions);
+
+        final Messages processed = interpreter.process(messageInDefaultStream("message", "test"));
+
+        final List<Message> messages = ImmutableList.copyOf(processed);
+        assertThat(messages).hasSize(1);
+
+        final Message actualMessage = messages.get(0);
+        assertThat(actualMessage.hasField("foobar")).isFalse();
+    }
+
+    @Test
+    public void testMatchEitherContinuesIfOneRuleMatched() {
+        final RuleService ruleService = mock(MongoDbRuleService.class);
+        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RULE_TRUE, RULE_FALSE, RULE_ADD_FOOBAR));
+
+        final PipelineService pipelineService = mock(MongoDbPipelineService.class);
+        when(pipelineService.loadAll()).thenReturn(Collections.singleton(
+                PipelineDao.create("p1", "title", "description",
+                        "pipeline \"pipeline\"\n" +
+                                "stage 0 match either\n" +
+                                "    rule \"true\";\n" +
+                                "    rule \"false\";\n" +
+                                "stage 1 match either\n" +
+                                "    rule \"add_foobar\";\n" +
+                                "end\n",
+                        Tools.nowUTC(),
+                        null)
+        ));
+
+        final Map<String, Function<?>> functions = ImmutableMap.of(SetField.NAME, new SetField());
+        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, functions);
+
+        final Messages processed = interpreter.process(messageInDefaultStream("message", "test"));
+
+        final List<Message> messages = ImmutableList.copyOf(processed);
+        assertThat(messages).hasSize(1);
+
+        final Message actualMessage = messages.get(0);
+        assertThat(actualMessage.getFieldAs(String.class, "foobar")).isEqualTo("covfefe");
+    }
+
+    @Test
+    public void testMatchEitherStopsIfNoRuleMatched() {
+        final RuleService ruleService = mock(MongoDbRuleService.class);
+        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RULE_TRUE, RULE_FALSE, RULE_ADD_FOOBAR));
+
+        final PipelineService pipelineService = mock(MongoDbPipelineService.class);
+        when(pipelineService.loadAll()).thenReturn(Collections.singleton(
+                PipelineDao.create("p1", "title", "description",
+                        "pipeline \"pipeline\"\n" +
+                                "stage 0 match either\n" +
+                                "    rule \"false\";\n" +
+                                "stage 1 match either\n" +
+                                "    rule \"add_foobar\";\n" +
+                                "end\n",
+                        Tools.nowUTC(),
+                        null)
+        ));
+
+        final Map<String, Function<?>> functions = ImmutableMap.of(SetField.NAME, new SetField());
+        final PipelineInterpreter interpreter = createPipelineInterpreter(ruleService, pipelineService, functions);
+
+        final Messages processed = interpreter.process(messageInDefaultStream("message", "test"));
+
+        final List<Message> messages = ImmutableList.copyOf(processed);
+        assertThat(messages).hasSize(1);
+
+        final Message actualMessage = messages.get(0);
+        assertThat(actualMessage.hasField("foobar")).isFalse();
+    }
+
+    private PipelineInterpreter createPipelineInterpreter(RuleService ruleService, PipelineService pipelineService, Map<String, Function<?>> functions) {
+        final PipelineStreamConnectionsService pipelineStreamConnectionsService = mock(MongoDbPipelineStreamConnectionsService.class);
+        final PipelineConnections pipelineConnections = PipelineConnections.create("p1", DEFAULT_STREAM_ID, Collections.singleton("p1"));
+        when(pipelineStreamConnectionsService.loadAll()).thenReturn(Collections.singleton(pipelineConnections));
 
         final FunctionRegistry functionRegistry = new FunctionRegistry(functions);
         final PipelineRuleParser parser = new PipelineRuleParser(functionRegistry, new CodeGenerator(JavaCompiler::new));
@@ -117,19 +261,13 @@ public class PipelineInterpreterTest {
                 functionRegistry,
                 Executors.newScheduledThreadPool(1),
                 mock(EventBus.class),
-                (currentPipelines, streamPipelineConnections, classLoader) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, null, new MetricRegistry(), 1, true),
+                (currentPipelines, streamPipelineConnections) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, new MetricRegistry(), 1, true),
                 false);
-        final PipelineInterpreter interpreter = new PipelineInterpreter(
+        return new PipelineInterpreter(
                 mock(Journal.class),
                 new MetricRegistry(),
                 stateUpdater
         );
-
-        Message msg = messageInDefaultStream("original message", "test");
-        final Messages processed = interpreter.process(msg);
-
-        final Message[] messages = Iterables.toArray(processed, Message.class);
-        assertEquals(2, messages.length);
     }
 
     @Test
@@ -161,11 +299,9 @@ public class PipelineInterpreterTest {
         final PipelineStreamConnectionsService pipelineStreamConnectionsService = new InMemoryPipelineStreamConnectionsService();
         pipelineStreamConnectionsService.save(PipelineConnections.create(null,
                 DEFAULT_STREAM_ID,
-                newHashSet("cde")));
+                Collections.singleton("cde")));
 
-        final Map<String, Function<?>> functions = Maps.newHashMap();
-
-        final FunctionRegistry functionRegistry = new FunctionRegistry(functions);
+        final FunctionRegistry functionRegistry = new FunctionRegistry(Collections.emptyMap());
         final PipelineRuleParser parser = new PipelineRuleParser(functionRegistry, new CodeGenerator(JavaCompiler::new));
 
         final MetricRegistry metricRegistry = new MetricRegistry();
@@ -176,7 +312,8 @@ public class PipelineInterpreterTest {
                 metricRegistry,
                 functionRegistry,
                 Executors.newScheduledThreadPool(1),
-                mock(EventBus.class), (currentPipelines, streamPipelineConnections, commonClassLoader) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, null, new MetricRegistry(), 1, true),
+                mock(EventBus.class),
+                (currentPipelines, streamPipelineConnections) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, new MetricRegistry(), 1, true),
                 false);
         final PipelineInterpreter interpreter = new PipelineInterpreter(
                 mock(Journal.class),
@@ -237,5 +374,4 @@ public class PipelineInterpreterTest {
 
         return msg;
     }
-
 }


### PR DESCRIPTION
The pipeline interpreter had a bug regarding the handling of the "match all" and "match either" statements which caused pipelines containing stages with "match all" to continue processing even if not all rules in the stage were executed.

Fixes Graylog2/graylog2-server#3924