### PR TITLE
Fix serialization/deserialization of StageSource

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineSource.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineSource.java
@@ -45,29 +45,29 @@ public abstract class PipelineSource {
     @ObjectId
     public abstract String id();
 
-    @JsonProperty
+    @JsonProperty("title")
     @Nullable
     public abstract String title();
 
-    @JsonProperty
+    @JsonProperty("description")
     @Nullable
     public abstract String description();
 
-    @JsonProperty
+    @JsonProperty("source")
     public abstract String source();
 
-    @JsonProperty
+    @JsonProperty("created_at")
     @Nullable
     public abstract DateTime createdAt();
 
-    @JsonProperty
+    @JsonProperty("modified_at")
     @Nullable
     public abstract DateTime modifiedAt();
 
-    @JsonProperty
+    @JsonProperty("stages")
     public abstract List<StageSource> stages();
 
-    @JsonProperty
+    @JsonProperty("errors")
     @Nullable
     public abstract Set<ParseError> errors();
 
@@ -82,6 +82,7 @@ public abstract class PipelineSource {
                                         @JsonProperty("title") String title,
                                         @JsonProperty("description") @Nullable String description,
                                         @JsonProperty("source") String source,
+                                        @Nullable @JsonProperty("stages") List<StageSource> stages,
                                         @Nullable @JsonProperty("created_at") DateTime createdAt,
                                         @Nullable @JsonProperty("modified_at") DateTime modifiedAt) {
         return builder()
@@ -91,7 +92,7 @@ public abstract class PipelineSource {
                 .source(source)
                 .createdAt(createdAt)
                 .modifiedAt(modifiedAt)
-                .stages(Collections.emptyList())
+                .stages(stages == null ? Collections.emptyList() : stages)
                 .build();
     }
 

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/rest/StageSource.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/rest/StageSource.java
@@ -16,22 +16,37 @@
  */
 package org.graylog.plugins.pipelineprocessor.rest;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
+import javax.validation.constraints.Min;
 import java.util.List;
 
 @AutoValue
+@JsonAutoDetect
 public abstract class StageSource {
-
-    @JsonProperty
+    @Min(0)
+    @JsonProperty("stage")
     public abstract int stage();
 
-    @JsonProperty
+    @JsonProperty("match_all")
     public abstract boolean matchAll();
 
-    @JsonProperty
+    @JsonProperty("rules")
     public abstract List<String> rules();
+
+    @JsonCreator
+    public static StageSource create(@JsonProperty("stage") @Min(0) int stage,
+                                     @JsonProperty("match_all") boolean matchAll,
+                                     @JsonProperty("rules") List<String> rules) {
+        return builder()
+                .stage(stage)
+                .matchAll(matchAll)
+                .rules(rules)
+                .build();
+    }
 
     public static Builder builder() {
         return new AutoValue_StageSource.Builder();

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/rest/PipelineSourceTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/rest/PipelineSourceTest.java
@@ -1,0 +1,87 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PipelineSourceTest {
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @Test
+    public void testSerialization() throws Exception {
+        final StageSource stageSource = StageSource.create(23, true, Collections.singletonList("some-rule"));
+        final PipelineSource pipelineSource = PipelineSource.create(
+                "id",
+                "title",
+                "description",
+                "source",
+                Collections.singletonList(stageSource),
+                new DateTime(2017, 7, 4, 15, 0, DateTimeZone.UTC),
+                new DateTime(2017, 7, 4, 15, 0, DateTimeZone.UTC)
+        );
+        final JsonNode json = objectMapper.convertValue(pipelineSource, JsonNode.class);
+
+        assertThat(json.path("id").asText()).isEqualTo("id");
+        assertThat(json.path("title").asText()).isEqualTo("title");
+        assertThat(json.path("description").asText()).isEqualTo("description");
+        assertThat(json.path("source").asText()).isEqualTo("source");
+        assertThat(json.path("created_at").asText()).isEqualTo("2017-07-04T15:00:00.000Z");
+        assertThat(json.path("modified_at").asText()).isEqualTo("2017-07-04T15:00:00.000Z");
+        assertThat(json.path("stages").isArray()).isTrue();
+        assertThat(json.path("stages")).hasSize(1);
+
+        final JsonNode stageNode = json.path("stages").get(0);
+        assertThat(stageNode.path("stage").asInt()).isEqualTo(23);
+        assertThat(stageNode.path("match_all").asBoolean()).isTrue();
+        assertThat(stageNode.path("rules").isArray()).isTrue();
+        assertThat(stageNode.path("rules")).hasSize(1);
+        assertThat(stageNode.path("rules").get(0).asText()).isEqualTo("some-rule");
+    }
+
+    @Test
+    public void testDeserialization() throws Exception {
+        final String json = "{"
+                + "\"id\":\"id\","
+                + "\"title\":\"title\","
+                + "\"description\":\"description\","
+                + "\"source\":\"source\","
+                + "\"created_at\":\"2017-07-04T15:00:00.000Z\","
+                + "\"modified_at\":\"2017-07-04T15:00:00.000Z\","
+                + "\"stages\":[{\"stage\":23,\"match_all\":true,\"rules\":[\"some-rule\"]}]"
+                + "}";
+
+        final PipelineSource pipelineSource = objectMapper.readValue(json, PipelineSource.class);
+        assertThat(pipelineSource.id()).isEqualTo("id");
+        assertThat(pipelineSource.title()).isEqualTo("title");
+        assertThat(pipelineSource.description()).isEqualTo("description");
+        assertThat(pipelineSource.source()).isEqualTo("source");
+        assertThat(pipelineSource.createdAt()).isEqualTo(new DateTime(2017, 7, 4, 15, 0, DateTimeZone.UTC));
+        assertThat(pipelineSource.modifiedAt()).isEqualTo(new DateTime(2017, 7, 4, 15, 0, DateTimeZone.UTC));
+        assertThat(pipelineSource.stages())
+                .hasSize(1)
+                .containsOnly(StageSource.create(23, true, Collections.singletonList("some-rule")));
+    }
+}

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/rest/StageSourceTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/rest/StageSourceTest.java
@@ -1,0 +1,53 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StageSourceTest {
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @Test
+    public void testSerialization() throws Exception {
+        final StageSource stageSource = StageSource.create(23, true, Collections.singletonList("some-rule"));
+        final JsonNode json = objectMapper.convertValue(stageSource, JsonNode.class);
+
+        assertThat(json.path("stage").asInt()).isEqualTo(23);
+        assertThat(json.path("match_all").asBoolean()).isTrue();
+        assertThat(json.path("rules").isArray()).isTrue();
+        assertThat(json.path("rules")).hasSize(1);
+        assertThat(json.path("rules").get(0).asText()).isEqualTo("some-rule");
+    }
+
+    @Test
+    public void testDeserialization() throws Exception {
+        final String json = "{\"stage\":23,\"match_all\":true,\"rules\":[\"some-rule\"]}";
+        final StageSource stageSource = objectMapper.readValue(json, StageSource.class);
+        assertThat(stageSource.stage()).isEqualTo(23);
+        assertThat(stageSource.matchAll()).isTrue();
+        assertThat(stageSource.rules())
+                .hasSize(1)
+                .containsOnly("some-rule");
+    }
+}


### PR DESCRIPTION
Some important Jackson annotations were missing from the StageSource class
which prevented proper deserialization via the Graylog REST API.

Fixes #194