### PR TITLE
Use friendlier error message in case of invalid expressions

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/UnaryExpression.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/UnaryExpression.java
@@ -17,6 +17,8 @@
 package org.graylog.plugins.pipelineprocessor.ast.expressions;
 
 import org.antlr.v4.runtime.Token;
+import org.graylog.plugins.pipelineprocessor.parser.ParseException;
+import org.graylog.plugins.pipelineprocessor.parser.errors.SyntaxError;
 
 import java.util.Collections;
 
@@ -26,7 +28,19 @@ public abstract class UnaryExpression extends BaseExpression {
 
     public UnaryExpression(Token start, Expression right) {
         super(start);
-        this.right = right;
+        this.right = requireNonNull(right, start);
+    }
+
+    private static Expression requireNonNull(Expression expression, Token token) {
+        if (expression != null) {
+            return expression;
+        } else {
+            final int line = token.getLine();
+            final int positionInLine = token.getCharPositionInLine();
+            final String msg = "Invalid expression (line: " + line + ", column: " + positionInLine + ")";
+            final SyntaxError syntaxError = new SyntaxError(token.getText(), line, positionInLine, msg, null);
+            throw new ParseException(Collections.singleton(syntaxError));
+        }
     }
 
     @Override

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/errors/SyntaxError.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/parser/errors/SyntaxError.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RecognitionException;
 
+import javax.annotation.Nullable;
+
 public class SyntaxError extends ParseError {
 
     private final Object offendingSymbol;
@@ -28,7 +30,7 @@ public class SyntaxError extends ParseError {
     private final String msg;
     private final RecognitionException e;
 
-    public SyntaxError(Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
+    public SyntaxError(@Nullable Object offendingSymbol, int line, int charPositionInLine, String msg, @Nullable RecognitionException e) {
         super("syntax_error", new ParserRuleContext());
 
         this.offendingSymbol = offendingSymbol;

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
-
 import org.graylog.plugins.pipelineprocessor.BaseParserTest;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
@@ -56,6 +55,7 @@ import org.graylog.plugins.pipelineprocessor.parser.errors.InvalidOperation;
 import org.graylog.plugins.pipelineprocessor.parser.errors.NonIndexableType;
 import org.graylog.plugins.pipelineprocessor.parser.errors.OptionalParametersMustBeNamed;
 import org.graylog.plugins.pipelineprocessor.parser.errors.ParseError;
+import org.graylog.plugins.pipelineprocessor.parser.errors.SyntaxError;
 import org.graylog.plugins.pipelineprocessor.parser.errors.UndeclaredFunction;
 import org.graylog.plugins.pipelineprocessor.parser.errors.UndeclaredVariable;
 import org.graylog2.plugin.InstantMillisProvider;
@@ -410,6 +410,17 @@ public class PipelineRuleParserTest extends BaseParserTest {
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
             assertEquals(InvalidOperation.class, Iterables.getOnlyElement(e.getErrors()).getClass());
+        }
+    }
+
+    @Test
+    public void issue185() {
+        try {
+            parseRuleWithOptionalCodegen();
+            fail("Should have thrown parse exception");
+        } catch (ParseException e) {
+            assertEquals(1, e.getErrors().size());
+            assertEquals(SyntaxError.class, Iterables.getOnlyElement(e.getErrors()).getClass());
         }
     }
 

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/parser/issue185.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/parser/issue185.txt
@@ -1,0 +1,6 @@
+rule "issue-185"
+when
+  true
+then
+  let a = "\s+$"
+end


### PR DESCRIPTION
Instead of throwing a `NullPointerException` for invalid unary expression where the constructor parameter `right` is `null` and for which the call to `UnaryExpression#getType()` will subsequently fail, the constructor now explicitly throws a `ParseException` with a `SyntaxError` (fail fast).

Closes #185