### PR TITLE
Support multiple matches in regex() function

### DIFF
--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -362,7 +362,13 @@ public class FunctionsSnippetsTest extends BaseParserTest {
             assertNotNull(message);
             assertTrue(message.hasField("matched_regex"));
             assertTrue(message.hasField("group_1"));
+            assertTrue(message.hasField("group_2a"));
+            assertTrue(message.hasField("group_2b"));
+            assertTrue(message.hasField("named_abc1"));
+            assertTrue(message.hasField("named_abc2"));
             assertThat((String) message.getField("named_group")).isEqualTo("cd.e");
+            assertThat((String) message.getField("named_abc1")).isEqualTo("abc");
+            assertThat((String) message.getField("named_abc2")).isEqualTo("abc");
         } catch (ParseException e) {
             Assert.fail("Should parse");
         }

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/regexMatch.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/regexMatch.txt
@@ -3,11 +3,20 @@ when
     regex("^.*(cde\\.)(:(\\d+))?.*$", "abcde.fg").matches == true &&
     regex(".*(cde\\.)(:(\\d+))?.*", "abcde.fg").matches == true &&
     regex("(cde\\.)(:(\\d+))?", "abcde.fg").matches == true &&
-    regex("^(cde\\.)(:(\\d+))?$", "abcde.fg").matches == false
+    regex("^(cde\\.)(:(\\d+))?$", "abcde.fg").matches == false &&
+    regex("(abc)", "abcabcabcabc").matches == true
 then
     let result = regex("(cd\\.e)", "abcd.efg");
     set_field("group_1", result["0"]);
+
+    let result = regex("(abc)", "abcabc");
+    set_field("group_2a", result["0"]);
+    set_field("group_2b", result["1"]);
+
     let result = regex("(cd\\.e)", "abcd.efg", ["name"]);
     set_field("named_group", result["name"]);
     set_field("matched_regex", result.matches);
+
+    let result = regex("(abc)", "abcabc", ["named_abc1", "named_abc2"]);
+    set_fields(result);
 end


### PR DESCRIPTION
The `regex()` function only returned a single match (similar to the Regex Extractor),
while some users require it to return all matches.

Fixes #173
Closes #174