### PR TITLE
Add list-related functions

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -53,6 +53,7 @@ import org.graylog.plugins.pipelineprocessor.functions.ips.CidrMatch;
 import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.Lookup;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupValue;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
@@ -127,6 +128,9 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(Concat.NAME, Concat.class);
         addMessageProcessorFunction(KeyValue.NAME, KeyValue.class);
         addMessageProcessorFunction(Split.NAME, Split.class);
+
+        // list functions
+        addMessageProcessorFunction(ListContains.NAME, ListContains.class);
 
         // json
         addMessageProcessorFunction(JsonParse.NAME, JsonParse.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -53,6 +53,7 @@ import org.graylog.plugins.pipelineprocessor.functions.ips.CidrMatch;
 import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListAdd;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContainsAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListIndexOf;
@@ -141,6 +142,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(Split.NAME, Split.class);
 
         // list functions
+        addMessageProcessorFunction(ListAdd.NAME, ListAdd.class);
         addMessageProcessorFunction(ListContains.NAME, ListContains.class);
         addMessageProcessorFunction(ListContainsAll.NAME, ListContainsAll.class);
         addMessageProcessorFunction(ListIndexOf.NAME, ListIndexOf.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -55,6 +55,8 @@ import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListIsEmpty;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemove;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAt;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.Lookup;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupValue;
@@ -135,6 +137,8 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(ListContains.NAME, ListContains.class);
         addMessageProcessorFunction(ListIsEmpty.NAME, ListIsEmpty.class);
         addMessageProcessorFunction(ListReverse.NAME, ListReverse.class);
+        addMessageProcessorFunction(ListRemoveAt.NAME, ListRemoveAt.class);
+        addMessageProcessorFunction(ListRemove.NAME, ListRemove.class);
 
         // json
         addMessageProcessorFunction(JsonParse.NAME, JsonParse.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -54,6 +54,7 @@ import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.Lookup;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupValue;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
@@ -131,6 +132,7 @@ public class ProcessorFunctionsModule extends PluginModule {
 
         // list functions
         addMessageProcessorFunction(ListContains.NAME, ListContains.class);
+        addMessageProcessorFunction(ListReverse.NAME, ListReverse.class);
 
         // json
         addMessageProcessorFunction(JsonParse.NAME, JsonParse.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -54,6 +54,7 @@ import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListAdd;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListAddAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContainsAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListIndexOf;
@@ -143,6 +144,7 @@ public class ProcessorFunctionsModule extends PluginModule {
 
         // list functions
         addMessageProcessorFunction(ListAdd.NAME, ListAdd.class);
+        addMessageProcessorFunction(ListAddAll.NAME, ListAddAll.class);
         addMessageProcessorFunction(ListContains.NAME, ListContains.class);
         addMessageProcessorFunction(ListContainsAll.NAME, ListContainsAll.class);
         addMessageProcessorFunction(ListIndexOf.NAME, ListIndexOf.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -63,6 +63,7 @@ import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAt;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRetainAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListSize;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListSubList;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.Lookup;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupValue;
@@ -145,6 +146,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(ListIndexOf.NAME, ListIndexOf.class);
         addMessageProcessorFunction(ListLastIndexOf.NAME, ListLastIndexOf.class);
         addMessageProcessorFunction(ListIsEmpty.NAME, ListIsEmpty.class);
+        addMessageProcessorFunction(ListSize.NAME, ListSize.class);
         addMessageProcessorFunction(ListReverse.NAME, ListReverse.class);
         addMessageProcessorFunction(ListRemoveAt.NAME, ListRemoveAt.class);
         addMessageProcessorFunction(ListRemove.NAME, ListRemove.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -54,6 +54,7 @@ import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListIsEmpty;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.Lookup;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupValue;
@@ -132,6 +133,7 @@ public class ProcessorFunctionsModule extends PluginModule {
 
         // list functions
         addMessageProcessorFunction(ListContains.NAME, ListContains.class);
+        addMessageProcessorFunction(ListIsEmpty.NAME, ListIsEmpty.class);
         addMessageProcessorFunction(ListReverse.NAME, ListReverse.class);
 
         // json

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -59,6 +59,7 @@ import org.graylog.plugins.pipelineprocessor.functions.lists.ListIndexOf;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListIsEmpty;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListLastIndexOf;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemove;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAt;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.Lookup;
@@ -145,6 +146,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(ListReverse.NAME, ListReverse.class);
         addMessageProcessorFunction(ListRemoveAt.NAME, ListRemoveAt.class);
         addMessageProcessorFunction(ListRemove.NAME, ListRemove.class);
+        addMessageProcessorFunction(ListRemoveAll.NAME, ListRemoveAll.class);
 
         // json
         addMessageProcessorFunction(JsonParse.NAME, JsonParse.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -61,6 +61,7 @@ import org.graylog.plugins.pipelineprocessor.functions.lists.ListLastIndexOf;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemove;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAt;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListRetainAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.Lookup;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupValue;
@@ -147,6 +148,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(ListRemoveAt.NAME, ListRemoveAt.class);
         addMessageProcessorFunction(ListRemove.NAME, ListRemove.class);
         addMessageProcessorFunction(ListRemoveAll.NAME, ListRemoveAll.class);
+        addMessageProcessorFunction(ListRetainAll.NAME, ListRetainAll.class);
 
         // json
         addMessageProcessorFunction(JsonParse.NAME, JsonParse.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -63,6 +63,7 @@ import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAt;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRetainAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListSubList;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.Lookup;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupValue;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
@@ -149,6 +150,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(ListRemove.NAME, ListRemove.class);
         addMessageProcessorFunction(ListRemoveAll.NAME, ListRemoveAll.class);
         addMessageProcessorFunction(ListRetainAll.NAME, ListRetainAll.class);
+        addMessageProcessorFunction(ListSubList.NAME, ListSubList.class);
 
         // json
         addMessageProcessorFunction(JsonParse.NAME, JsonParse.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -54,7 +54,9 @@ import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListIndexOf;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListIsEmpty;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListLastIndexOf;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemove;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAt;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
@@ -135,6 +137,8 @@ public class ProcessorFunctionsModule extends PluginModule {
 
         // list functions
         addMessageProcessorFunction(ListContains.NAME, ListContains.class);
+        addMessageProcessorFunction(ListIndexOf.NAME, ListIndexOf.class);
+        addMessageProcessorFunction(ListLastIndexOf.NAME, ListLastIndexOf.class);
         addMessageProcessorFunction(ListIsEmpty.NAME, ListIsEmpty.class);
         addMessageProcessorFunction(ListReverse.NAME, ListReverse.class);
         addMessageProcessorFunction(ListRemoveAt.NAME, ListRemoveAt.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -54,6 +54,7 @@ import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListContainsAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListIndexOf;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListIsEmpty;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListLastIndexOf;
@@ -137,6 +138,7 @@ public class ProcessorFunctionsModule extends PluginModule {
 
         // list functions
         addMessageProcessorFunction(ListContains.NAME, ListContains.class);
+        addMessageProcessorFunction(ListContainsAll.NAME, ListContainsAll.class);
         addMessageProcessorFunction(ListIndexOf.NAME, ListIndexOf.class);
         addMessageProcessorFunction(ListLastIndexOf.NAME, ListLastIndexOf.class);
         addMessageProcessorFunction(ListIsEmpty.NAME, ListIsEmpty.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListAdd.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListAdd.java
@@ -1,0 +1,65 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lists;
+
+import com.google.common.collect.ImmutableList;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ListAdd extends AbstractFunction<List> {
+
+    public static final String NAME = "list_add";
+    private final ParameterDescriptor<Object, List> listParam;
+    private final ParameterDescriptor<Object, Object> elementParam;
+
+    public ListAdd() {
+        listParam = ParameterDescriptor.object("list", List.class).description("The list to modify").build();
+        elementParam = ParameterDescriptor.object("element").description("The element to add").build();
+    }
+
+    @Override
+    public List evaluate(FunctionArgs args, EvaluationContext context) {
+        @SuppressWarnings("unchecked") final List<? extends Object> list = (List<? extends Object>) listParam.required(args, context);
+        final Object element = elementParam.required(args, context);
+
+        if (list == null || element == null) {
+            return list;
+        }
+
+        return ImmutableList.builder()
+                .addAll(list)
+                .add(element)
+                .build();
+    }
+
+    @Override
+    public FunctionDescriptor<List> descriptor() {
+        return FunctionDescriptor.<List>builder()
+                .name(NAME)
+                .returnType(List.class)
+                .params(of(listParam, elementParam))
+                .description("Append element to list")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListAddAll.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListAddAll.java
@@ -1,0 +1,69 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lists;
+
+import com.google.common.collect.ImmutableList;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ListAddAll extends AbstractFunction<List> {
+
+    public static final String NAME = "list_add_all";
+    private final ParameterDescriptor<Object, List> listParam;
+    private final ParameterDescriptor<Object, List> elementsParam;
+
+    public ListAddAll() {
+        listParam = ParameterDescriptor.object("list", List.class).description("The list to modify").build();
+        elementsParam = ParameterDescriptor.object("elements", List.class).description("The elements to add").build();
+    }
+
+    @Override
+    public List evaluate(FunctionArgs args, EvaluationContext context) {
+        @SuppressWarnings("unchecked") final List<? extends Object> list = (List<? extends Object>) listParam.required(args, context);
+        final List elements = elementsParam.required(args, context);
+
+        if (list == null || elements == null || elements.isEmpty()) {
+            return list;
+        }
+
+        if (list.isEmpty()) {
+            return elements;
+        }
+
+        return ImmutableList.builder()
+                .addAll(list)
+                .addAll(elements)
+                .build();
+    }
+
+    @Override
+    public FunctionDescriptor<List> descriptor() {
+        return FunctionDescriptor.<List>builder()
+                .name(NAME)
+                .returnType(List.class)
+                .params(of(listParam, elementsParam))
+                .description("Append elements to a list")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListContains.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListContains.java
@@ -1,0 +1,57 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lists;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ListContains extends AbstractFunction<Boolean> {
+
+    public static final String NAME = "list_contains";
+    private final ParameterDescriptor<Object, List> listParam;
+    private final ParameterDescriptor<Object, Object> elementParam;
+
+    public ListContains() {
+        listParam = ParameterDescriptor.object("list", List.class).description("The list to check").build();
+        elementParam = ParameterDescriptor.object("element").description("The element to find").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final List list = listParam.required(args, context);
+        final Object element = elementParam.required(args, context);
+
+        return list != null && list.contains(element);
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(of(listParam, elementParam))
+                .description("Checks if a list contains a specific element")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListContainsAll.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListContainsAll.java
@@ -1,0 +1,57 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lists;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ListContainsAll extends AbstractFunction<Boolean> {
+
+    public static final String NAME = "list_contains_all";
+    private final ParameterDescriptor<Object, List> listParam;
+    private final ParameterDescriptor<Object, List> elementsParam;
+
+    public ListContainsAll() {
+        listParam = ParameterDescriptor.object("list", List.class).description("The list to check").build();
+        elementsParam = ParameterDescriptor.object("elements", List.class).description("The elements to find").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final List list = listParam.required(args, context);
+        final List elements = elementsParam.required(args, context);
+
+        return list != null && elements != null && list.containsAll(elements);
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(of(listParam, elementsParam))
+                .description("Checks if a list contains specific elements")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListIndexOf.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListIndexOf.java
@@ -1,0 +1,57 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lists;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ListIndexOf extends AbstractFunction<Long> {
+
+    public static final String NAME = "list_index_of";
+    private final ParameterDescriptor<Object, List> listParam;
+    private final ParameterDescriptor<Object, Object> elementParam;
+
+    public ListIndexOf() {
+        listParam = ParameterDescriptor.object("list", List.class).description("The list to check").build();
+        elementParam = ParameterDescriptor.object("element").description("The element to find").build();
+    }
+
+    @Override
+    public Long evaluate(FunctionArgs args, EvaluationContext context) {
+        final List value = listParam.required(args, context);
+        final Object search = elementParam.required(args, context);
+
+        return value == null ? null : (long) value.indexOf(search);
+    }
+
+    @Override
+    public FunctionDescriptor<Long> descriptor() {
+        return FunctionDescriptor.<Long>builder()
+                .name(NAME)
+                .returnType(Long.class)
+                .params(of(listParam, elementParam))
+                .description("Returns the index of a specific element in a list")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListIsEmpty.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListIsEmpty.java
@@ -1,0 +1,54 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lists;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ListIsEmpty extends AbstractFunction<Boolean> {
+
+    public static final String NAME = "list_is_empty";
+    private final ParameterDescriptor<Object, List> listParam;
+
+    public ListIsEmpty() {
+        listParam = ParameterDescriptor.object("list", List.class).description("The list to check").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final List list = listParam.required(args, context);
+
+        return list == null || list.isEmpty();
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(of(listParam))
+                .description("Checks if a list is empty")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListLastIndexOf.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListLastIndexOf.java
@@ -1,0 +1,57 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lists;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ListLastIndexOf extends AbstractFunction<Long> {
+
+    public static final String NAME = "list_last_index_of";
+    private final ParameterDescriptor<Object, List> listParam;
+    private final ParameterDescriptor<Object, Object> elementParam;
+
+    public ListLastIndexOf() {
+        listParam = ParameterDescriptor.object("list", List.class).description("The list to check").build();
+        elementParam = ParameterDescriptor.object("element").description("The element to find").build();
+    }
+
+    @Override
+    public Long evaluate(FunctionArgs args, EvaluationContext context) {
+        final List list = listParam.required(args, context);
+        final Object element = elementParam.required(args, context);
+
+        return list == null ? null : (long) list.lastIndexOf(element);
+    }
+
+    @Override
+    public FunctionDescriptor<Long> descriptor() {
+        return FunctionDescriptor.<Long>builder()
+                .name(NAME)
+                .returnType(Long.class)
+                .params(of(listParam, elementParam))
+                .description("Returns the last index of a specific element in a list")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListRemove.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListRemove.java
@@ -1,0 +1,65 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lists;
+
+import com.google.common.collect.ImmutableList;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ListRemove extends AbstractFunction<List> {
+
+    public static final String NAME = "list_remove";
+    private final ParameterDescriptor<Object, List> listParam;
+    private final ParameterDescriptor<Object, Object> elementParam;
+
+    public ListRemove() {
+        listParam = ParameterDescriptor.object("list", List.class).description("The list to modify").build();
+        elementParam = ParameterDescriptor.object("element").description("The element to remove").build();
+    }
+
+    @Override
+    public List evaluate(FunctionArgs args, EvaluationContext context) {
+        @SuppressWarnings("unchecked")
+        final List<? extends Object> list = (List<? extends Object>) listParam.required(args, context);
+        final Object element = elementParam.required(args, context);
+
+        if (list == null) {
+            return null;
+        }
+
+        return list.stream()
+                .filter(x -> x != null && !x.equals(element))
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    @Override
+    public FunctionDescriptor<List> descriptor() {
+        return FunctionDescriptor.<List>builder()
+                .name(NAME)
+                .returnType(List.class)
+                .params(of(listParam, elementParam))
+                .description("Remove element from list")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListRemoveAll.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListRemoveAll.java
@@ -1,0 +1,69 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lists;
+
+import com.google.common.collect.ImmutableList;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ListRemoveAll extends AbstractFunction<List> {
+
+    public static final String NAME = "list_remove_all";
+    private final ParameterDescriptor<Object, List> listParam;
+    private final ParameterDescriptor<Object, List> elementsParam;
+
+    public ListRemoveAll() {
+        listParam = ParameterDescriptor.object("list", List.class).description("The list to modify").build();
+        elementsParam = ParameterDescriptor.object("elements", List.class).description("The elements to remove").build();
+    }
+
+    @Override
+    public List evaluate(FunctionArgs args, EvaluationContext context) {
+        @SuppressWarnings("unchecked")
+        final List<? extends Object> list = (List<? extends Object>) listParam.required(args, context);
+        final List elements = elementsParam.required(args, context);
+
+        if (list == null) {
+            return null;
+        }
+
+        if(elements == null || elements.isEmpty()) {
+            return list;
+        }
+
+        return list.stream()
+                .filter(x -> x != null && !elements.contains(x))
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    @Override
+    public FunctionDescriptor<List> descriptor() {
+        return FunctionDescriptor.<List>builder()
+                .name(NAME)
+                .returnType(List.class)
+                .params(of(listParam, elementsParam))
+                .description("Remove elements from list")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListRemoveAt.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListRemoveAt.java
@@ -1,0 +1,70 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lists;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ListRemoveAt extends AbstractFunction<List> {
+
+    public static final String NAME = "list_remove_at";
+    private final ParameterDescriptor<Object, List> listParam;
+    private final ParameterDescriptor<Long, Long> indexParam;
+
+    public ListRemoveAt() {
+        listParam = ParameterDescriptor.object("list", List.class).description("The list to modify").build();
+        indexParam = ParameterDescriptor.integer("index").description("The list index to remove").build();
+    }
+
+    @Override
+    public List evaluate(FunctionArgs args, EvaluationContext context) {
+        final List list = listParam.required(args, context);
+        final Long index = indexParam.required(args, context);
+
+        if (list == null || index == null) {
+            return null;
+        }
+
+        final int listIndex = index.intValue();
+        final ImmutableList.Builder<Object> listBuilder = ImmutableList.builder();
+        for (int i = 0; i < list.size(); i++) {
+            if (i != listIndex) {
+                listBuilder.add(list.get(i));
+            }
+        }
+        return listBuilder.build();
+    }
+
+    @Override
+    public FunctionDescriptor<List> descriptor() {
+        return FunctionDescriptor.<List>builder()
+                .name(NAME)
+                .returnType(List.class)
+                .params(of(listParam, indexParam))
+                .description("Remove a specific index from a list")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListRetainAll.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListRetainAll.java
@@ -1,0 +1,70 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lists;
+
+import com.google.common.collect.ImmutableList;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ListRetainAll extends AbstractFunction<List> {
+
+    public static final String NAME = "list_retain_all";
+    private final ParameterDescriptor<Object, List> listParam;
+    private final ParameterDescriptor<Object, List> elementsParam;
+
+    public ListRetainAll() {
+        listParam = ParameterDescriptor.object("list", List.class).description("The list to modify").build();
+        elementsParam = ParameterDescriptor.object("elements", List.class).description("The elements to retain").build();
+    }
+
+    @Override
+    public List evaluate(FunctionArgs args, EvaluationContext context) {
+        @SuppressWarnings("unchecked")
+        final List<? extends Object> list = (List<? extends Object>) listParam.required(args, context);
+        final List elements = elementsParam.required(args, context);
+
+        if (list == null) {
+            return null;
+        }
+
+        if(elements == null || elements.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return list.stream()
+                .filter(x -> x != null && elements.contains(x))
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    @Override
+    public FunctionDescriptor<List> descriptor() {
+        return FunctionDescriptor.<List>builder()
+                .name(NAME)
+                .returnType(List.class)
+                .params(of(listParam, elementsParam))
+                .description("Retain elements in a list")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListReverse.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListReverse.java
@@ -1,0 +1,56 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lists;
+
+import com.google.common.collect.Lists;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ListReverse extends AbstractFunction<List> {
+
+    public static final String NAME = "list_reverse";
+    private final ParameterDescriptor<Object, List> listParam;
+
+    public ListReverse() {
+        listParam = ParameterDescriptor.object("list", List.class).description("The list to reverse").build();
+    }
+
+    @Override
+    public List evaluate(FunctionArgs args, EvaluationContext context) {
+        @SuppressWarnings("unchecked")
+        final List<? extends Object> list = (List<? extends Object>) listParam.required(args, context);
+
+        return list == null ? null : Lists.reverse(list);
+    }
+
+    @Override
+    public FunctionDescriptor<List> descriptor() {
+        return FunctionDescriptor.<List>builder()
+                .name(NAME)
+                .returnType(List.class)
+                .params(of(listParam))
+                .description("Reverses the order of the given list")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListSize.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListSize.java
@@ -1,0 +1,54 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lists;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ListSize extends AbstractFunction<Long> {
+
+    public static final String NAME = "list_size";
+    private final ParameterDescriptor<Object, List> listParam;
+
+    public ListSize() {
+        listParam = ParameterDescriptor.object("list", List.class).description("The list to check").build();
+    }
+
+    @Override
+    public Long evaluate(FunctionArgs args, EvaluationContext context) {
+        final List list = listParam.required(args, context);
+
+        return list == null ? null : (long) list.size();
+    }
+
+    @Override
+    public FunctionDescriptor<Long> descriptor() {
+        return FunctionDescriptor.<Long>builder()
+                .name(NAME)
+                .returnType(Long.class)
+                .params(of(listParam))
+                .description("Returns the length of a list")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListSubList.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lists/ListSubList.java
@@ -1,0 +1,74 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lists;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class ListSubList extends AbstractFunction<List> {
+
+    public static final String NAME = "sub_list";
+    private final ParameterDescriptor<Object, List> listParam;
+    private final ParameterDescriptor<Long, Long> startParam;
+    private final ParameterDescriptor<Long, Long> endParam;
+
+    public ListSubList() {
+        listParam = ParameterDescriptor.object("list", List.class).description("The list to create a sublist from").build();
+        startParam = ParameterDescriptor.integer("from").description("Start index (inclusive)").build();
+        endParam = ParameterDescriptor.integer("to").description("End index (exclusive)").build();
+    }
+
+    @Override
+    public List evaluate(FunctionArgs args, EvaluationContext context) {
+        @SuppressWarnings("unchecked") final List<? extends Object> list = (List<? extends Object>) listParam.required(args, context);
+        final Long startLong = startParam.required(args, context);
+        final Long endLong = endParam.required(args, context);
+
+        if (list == null) {
+            return null;
+        }
+
+        if (startLong == null || endLong == null) {
+            return list;
+        }
+
+        final int start = startLong.intValue();
+        final int end = endLong.intValue();
+        if (start < 0 || end < 0 || end < start || start >= list.size() || end > list.size()) {
+            return list;
+        }
+
+        return list.subList(start, end);
+    }
+
+    @Override
+    public FunctionDescriptor<List> descriptor() {
+        return FunctionDescriptor.<List>builder()
+                .name(NAME)
+                .returnType(List.class)
+                .params(of(listParam, startParam, endParam))
+                .description("Create a sublist")
+                .build();
+    }
+}

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -59,7 +59,9 @@ import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListIndexOf;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListIsEmpty;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListLastIndexOf;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemove;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAt;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
@@ -236,6 +238,8 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(SyslogLevelConversion.NAME, new SyslogLevelConversion());
 
         functions.put(ListContains.NAME, new ListContains());
+        functions.put(ListIndexOf.NAME, new ListIndexOf());
+        functions.put(ListLastIndexOf.NAME, new ListLastIndexOf());
         functions.put(ListIsEmpty.NAME, new ListIsEmpty());
         functions.put(ListReverse.NAME, new ListReverse());
         functions.put(ListRemoveAt.NAME, new ListRemoveAt());

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -59,6 +59,7 @@ import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListContainsAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListIndexOf;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListIsEmpty;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListLastIndexOf;
@@ -238,6 +239,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(SyslogLevelConversion.NAME, new SyslogLevelConversion());
 
         functions.put(ListContains.NAME, new ListContains());
+        functions.put(ListContainsAll.NAME, new ListContainsAll());
         functions.put(ListIndexOf.NAME, new ListIndexOf());
         functions.put(ListLastIndexOf.NAME, new ListLastIndexOf());
         functions.put(ListIsEmpty.NAME, new ListIsEmpty());

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -68,6 +68,7 @@ import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAt;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRetainAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListSize;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListSubList;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
@@ -246,6 +247,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(ListIndexOf.NAME, new ListIndexOf());
         functions.put(ListLastIndexOf.NAME, new ListLastIndexOf());
         functions.put(ListIsEmpty.NAME, new ListIsEmpty());
+        functions.put(ListSize.NAME, new ListSize());
         functions.put(ListReverse.NAME, new ListReverse());
         functions.put(ListRemoveAt.NAME, new ListRemoveAt());
         functions.put(ListRemove.NAME, new ListRemove());

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -59,6 +59,7 @@ import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.DropMessage;
@@ -232,6 +233,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(SyslogLevelConversion.NAME, new SyslogLevelConversion());
 
         functions.put(ListContains.NAME, new ListContains());
+        functions.put(ListReverse.NAME, new ListReverse());
 
         functions.put(UrlConversion.NAME, new UrlConversion());
 

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -16,15 +16,13 @@
  */
 package org.graylog.plugins.pipelineprocessor.functions;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.net.InetAddresses;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.graylog.plugins.pipelineprocessor.BaseParserTest;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
@@ -60,6 +58,7 @@ import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddress;
 import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.DropMessage;
@@ -232,6 +231,8 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(SyslogFacilityConversion.NAME, new SyslogFacilityConversion());
         functions.put(SyslogLevelConversion.NAME, new SyslogLevelConversion());
 
+        functions.put(ListContains.NAME, new ListContains());
+
         functions.put(UrlConversion.NAME, new UrlConversion());
 
         final GrokPatternService grokPatternService = mock(GrokPatternService.class);
@@ -379,6 +380,15 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat((boolean) message.getField("has_xyz")).isFalse();
         assertThat(message.getField("string_literal")).isInstanceOf(String.class);
         assertThat((String) message.getField("string_literal")).isEqualTo("abcd\\.e\tfg\u03a9\363");
+    }
+
+    @Test
+    public void lists() {
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final Message message = evaluateRule(rule);
+
+        assertThat(actionsTriggered.get()).isTrue();
+        assertThat(message).isNotNull();
     }
 
     @Test

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -59,6 +59,7 @@ import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListAdd;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListAddAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContainsAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListIndexOf;
@@ -244,6 +245,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(SyslogLevelConversion.NAME, new SyslogLevelConversion());
 
         functions.put(ListAdd.NAME, new ListAdd());
+        functions.put(ListAddAll.NAME, new ListAddAll());
         functions.put(ListContains.NAME, new ListContains());
         functions.put(ListContainsAll.NAME, new ListContainsAll());
         functions.put(ListIndexOf.NAME, new ListIndexOf());

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -58,6 +58,7 @@ import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddress;
 import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListAdd;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContainsAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListIndexOf;
@@ -242,6 +243,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(SyslogFacilityConversion.NAME, new SyslogFacilityConversion());
         functions.put(SyslogLevelConversion.NAME, new SyslogLevelConversion());
 
+        functions.put(ListAdd.NAME, new ListAdd());
         functions.put(ListContains.NAME, new ListContains());
         functions.put(ListContainsAll.NAME, new ListContainsAll());
         functions.put(ListIndexOf.NAME, new ListIndexOf());

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -66,6 +66,7 @@ import org.graylog.plugins.pipelineprocessor.functions.lists.ListLastIndexOf;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemove;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAt;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListRetainAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
@@ -248,6 +249,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(ListRemoveAt.NAME, new ListRemoveAt());
         functions.put(ListRemove.NAME, new ListRemove());
         functions.put(ListRemoveAll.NAME, new ListRemoveAll());
+        functions.put(ListRetainAll.NAME, new ListRetainAll());
 
         functions.put(UrlConversion.NAME, new UrlConversion());
 

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -60,6 +60,8 @@ import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListIsEmpty;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemove;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAt;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
@@ -236,6 +238,8 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(ListContains.NAME, new ListContains());
         functions.put(ListIsEmpty.NAME, new ListIsEmpty());
         functions.put(ListReverse.NAME, new ListReverse());
+        functions.put(ListRemoveAt.NAME, new ListRemoveAt());
+        functions.put(ListRemove.NAME, new ListRemove());
 
         functions.put(UrlConversion.NAME, new UrlConversion());
 

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -68,6 +68,7 @@ import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAt;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRetainAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListSubList;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.DropMessage;
@@ -250,6 +251,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(ListRemove.NAME, new ListRemove());
         functions.put(ListRemoveAll.NAME, new ListRemoveAll());
         functions.put(ListRetainAll.NAME, new ListRetainAll());
+        functions.put(ListSubList.NAME, new ListSubList());
 
         functions.put(UrlConversion.NAME, new UrlConversion());
 

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -64,6 +64,7 @@ import org.graylog.plugins.pipelineprocessor.functions.lists.ListIndexOf;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListIsEmpty;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListLastIndexOf;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemove;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAll;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListRemoveAt;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
@@ -246,6 +247,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(ListReverse.NAME, new ListReverse());
         functions.put(ListRemoveAt.NAME, new ListRemoveAt());
         functions.put(ListRemove.NAME, new ListRemove());
+        functions.put(ListRemoveAll.NAME, new ListRemoveAll());
 
         functions.put(UrlConversion.NAME, new UrlConversion());
 

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -59,6 +59,7 @@ import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListContains;
+import org.graylog.plugins.pipelineprocessor.functions.lists.ListIsEmpty;
 import org.graylog.plugins.pipelineprocessor.functions.lists.ListReverse;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
@@ -233,6 +234,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(SyslogLevelConversion.NAME, new SyslogLevelConversion());
 
         functions.put(ListContains.NAME, new ListContains());
+        functions.put(ListIsEmpty.NAME, new ListIsEmpty());
         functions.put(ListReverse.NAME, new ListReverse());
 
         functions.put(UrlConversion.NAME, new UrlConversion());

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
@@ -6,6 +6,14 @@ when
     list_contains(["foo", 23, false], 23) &&
     !list_contains(["foo"], 23) &&
     !list_contains([], 23) &&
+    list_index_of(["foo", "bar"], "foo") == 0 &&
+    list_index_of(["foo", "bar"], "bar") == 1 &&
+    list_index_of(["foo", "foo", "foo"], "foo") == 0 &&
+    list_index_of([1, 2], "foo") == -1 &&
+    list_last_index_of(["foo", "bar"], "foo") == 0 &&
+    list_last_index_of(["foo", "bar"], "bar") == 1 &&
+    list_last_index_of(["foo", "foo", "foo"], "foo") == 2 &&
+    list_last_index_of([1, 2], "foo") == -1 &&
     list_is_empty([]) &&
     !list_is_empty(["foo"]) &&
     list_reverse([]) == [] &&

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
@@ -44,7 +44,14 @@ when
     list_remove_all(["foo", "bar", "baz"], ["foo", "bar", "baz"]) == [] &&
     list_remove_all(["foo", "foo", "foo"], ["foo"]) == [] &&
     list_remove_all(["foo", "bar"], ["baz"]) == ["foo", "bar"] &&
-    list_remove_all([], ["foo"]) == []
+    list_remove_all([], ["foo"]) == [] &&
+    list_retain_all(["foo", "bar", "baz"], ["foo"]) == ["foo"] &&
+    list_retain_all(["foo", "bar", "baz"], ["foo", "bar"]) == ["foo", "bar"] &&
+    list_retain_all(["foo", "bar", "baz"], ["foo", "bar", "baz"]) == ["foo", "bar", "baz"] &&
+    list_retain_all(["foo", "foo", "foo"], ["foo"]) == ["foo", "foo", "foo"] &&
+    list_retain_all(["foo", "bar"], ["baz"]) == [] &&
+    list_retain_all(["foo", "bar"], []) == [] &&
+    list_retain_all([], ["foo"]) == []
 then
     trigger_test();
 end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
@@ -6,6 +6,15 @@ when
     list_contains(["foo", 23, false], 23) &&
     !list_contains(["foo"], 23) &&
     !list_contains([], 23) &&
+    list_contains_all(["foo", "bar"], ["foo"]) &&
+    list_contains_all(["foo", "bar"], ["foo", "bar"]) &&
+    list_contains_all([1, 2, 3], [1]) &&
+    list_contains_all([1, 2, 3], [1, 2]) &&
+    list_contains_all([true, false], [true]) &&
+    list_contains_all(["foo", 23, false], ["foo", 23]) &&
+    list_contains_all([], []) &&
+    !list_contains_all(["foo"], [23]) &&
+    !list_contains_all([], [23]) &&
     list_index_of(["foo", "bar"], "foo") == 0 &&
     list_index_of(["foo", "bar"], "bar") == 1 &&
     list_index_of(["foo", "foo", "foo"], "foo") == 0 &&

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
@@ -1,5 +1,8 @@
 rule "list tests"
 when
+    list_add([], "foo") == ["foo"] &&
+    list_add(["foo", "bar"], "baz") == ["foo", "bar", "baz"] &&
+    list_add(["foo"], 1) == ["foo", 1] &&
     list_contains(["foo", "bar"], "foo") &&
     list_contains([1, 2, 3], 2) &&
     list_contains([true, false], true) &&

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
@@ -1,0 +1,11 @@
+rule "list tests"
+when
+    list_contains(["foo", "bar"], "foo") &&
+    list_contains([1, 2, 3], 2) &&
+    list_contains([true, false], true) &&
+    list_contains(["foo", 23, false], 23) &&
+    !list_contains(["foo"], 23) &&
+    !list_contains([], 23)
+then
+    trigger_test();
+end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
@@ -51,7 +51,11 @@ when
     list_retain_all(["foo", "foo", "foo"], ["foo"]) == ["foo", "foo", "foo"] &&
     list_retain_all(["foo", "bar"], ["baz"]) == [] &&
     list_retain_all(["foo", "bar"], []) == [] &&
-    list_retain_all([], ["foo"]) == []
+    list_retain_all([], ["foo"]) == [] &&
+    sub_list([], 0, 0) == [] &&
+    sub_list([], 0, 100) == [] &&
+    sub_list([1, 2, 3], 90, 100) == [1, 2, 3] &&
+    sub_list([1, 2, 3], 1, 3) == [2, 3]
 then
     trigger_test();
 end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
@@ -38,7 +38,13 @@ when
     list_remove(["foo", "bar", "baz"], "foo") == ["bar", "baz"] &&
     list_remove(["foo", "foo", "foo"], "foo") == [] &&
     list_remove(["foo", "bar"], "baz") == ["foo", "bar"] &&
-    list_remove([], "foo") == []
+    list_remove([], "foo") == [] &&
+    list_remove_all(["foo", "bar", "baz"], ["foo"]) == ["bar", "baz"] &&
+    list_remove_all(["foo", "bar", "baz"], ["foo", "bar"]) == ["baz"] &&
+    list_remove_all(["foo", "bar", "baz"], ["foo", "bar", "baz"]) == [] &&
+    list_remove_all(["foo", "foo", "foo"], ["foo"]) == [] &&
+    list_remove_all(["foo", "bar"], ["baz"]) == ["foo", "bar"] &&
+    list_remove_all([], ["foo"]) == []
 then
     trigger_test();
 end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
@@ -6,6 +6,8 @@ when
     list_contains(["foo", 23, false], 23) &&
     !list_contains(["foo"], 23) &&
     !list_contains([], 23) &&
+    list_is_empty([]) &&
+    !list_is_empty(["foo"]) &&
     list_reverse([]) == [] &&
     list_reverse([1, 2, 3]) == [3, 2, 1] &&
     list_reverse(["foo", "bar", "baz"]) == ["baz", "bar", "foo"] &&

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
@@ -12,7 +12,16 @@ when
     list_reverse([1, 2, 3]) == [3, 2, 1] &&
     list_reverse(["foo", "bar", "baz"]) == ["baz", "bar", "foo"] &&
     list_reverse([true, false]) == [false, true] &&
-    list_reverse([1, "foo", false]) == [false, "foo", 1]
+    list_reverse([1, "foo", false]) == [false, "foo", 1] &&
+    list_remove_at([1, 2, 3], 0) == [2, 3] &&
+    list_remove_at([1, 2, 3], 1) == [1, 3] &&
+    list_remove_at([1, 2, 3], 2) == [1, 2] &&
+    list_remove_at([1], 5) == [1] &&
+    list_remove_at([], 0) == [] &&
+    list_remove(["foo", "bar", "baz"], "foo") == ["bar", "baz"] &&
+    list_remove(["foo", "foo", "foo"], "foo") == [] &&
+    list_remove(["foo", "bar"], "baz") == ["foo", "bar"] &&
+    list_remove([], "foo") == []
 then
     trigger_test();
 end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
@@ -3,6 +3,10 @@ when
     list_add([], "foo") == ["foo"] &&
     list_add(["foo", "bar"], "baz") == ["foo", "bar", "baz"] &&
     list_add(["foo"], 1) == ["foo", 1] &&
+    list_add_all([], ["foo"]) == ["foo"] &&
+    list_add_all(["foo"], ["bar", "baz"]) == ["foo", "bar", "baz"] &&
+    list_add_all(["foo"], []) == ["foo"] &&
+    list_add_all(["foo"], [1, true]) == ["foo", 1, true] &&
     list_contains(["foo", "bar"], "foo") &&
     list_contains([1, 2, 3], 2) &&
     list_contains([true, false], true) &&

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
@@ -5,7 +5,12 @@ when
     list_contains([true, false], true) &&
     list_contains(["foo", 23, false], 23) &&
     !list_contains(["foo"], 23) &&
-    !list_contains([], 23)
+    !list_contains([], 23) &&
+    list_reverse([]) == [] &&
+    list_reverse([1, 2, 3]) == [3, 2, 1] &&
+    list_reverse(["foo", "bar", "baz"]) == ["baz", "bar", "foo"] &&
+    list_reverse([true, false]) == [false, true] &&
+    list_reverse([1, "foo", false]) == [false, "foo", 1]
 then
     trigger_test();
 end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lists.txt
@@ -25,6 +25,9 @@ when
     list_last_index_of([1, 2], "foo") == -1 &&
     list_is_empty([]) &&
     !list_is_empty(["foo"]) &&
+    list_size([]) == 0 &&
+    list_size(["foo"]) == 1 &&
+    list_size(["foo", "bar", 1, 2, true, false]) == 6 &&
     list_reverse([]) == [] &&
     list_reverse([1, 2, 3]) == [3, 2, 1] &&
     list_reverse(["foo", "bar", "baz"]) == ["baz", "bar", "foo"] &&


### PR DESCRIPTION
This change set adds several list-related functions to the pipeline processor:

* `list_contains()`
* `list_contains_all()`
* `list_is_empty()`
* `list_size()`
* `list_index_of()`
* `list_last_index_of()`
* `list_add()`
* `list_add_all()`
* `list_remove()`
* `list_remove_at()`
* `list_remove_all()`
* `list_retain_all()`
* `list_reverse()`
* `sub_list()`