### PR TITLE
Make "locale" parameter of "parse_date()" optional

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/ParseDate.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/ParseDate.java
@@ -42,7 +42,7 @@ public class ParseDate extends TimezoneAwareFunction {
     public ParseDate() {
         valueParam = ParameterDescriptor.string(VALUE).description("Date string to parse").build();
         patternParam = ParameterDescriptor.string(PATTERN).description("The pattern to parse the date with, see http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html").build();
-        localeParam = ParameterDescriptor.string(LOCALE).description("The locale to parse the date with, see https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html").build();
+        localeParam = ParameterDescriptor.string(LOCALE).optional().description("The locale to parse the date with, see https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html").build();
     }
 
     @Override


### PR DESCRIPTION
The "locale" parameter of the `parse_date()` function is being processed as optional already,
but wasn't marked as such in the function signature.

Refs #202

(cherry picked from commit a7a9d19268c0117f3ba4bdcbef6e2d98b484f032)