### PR TITLE
parse_json() returns MissingNode if input wasn't valid JSON

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonParse.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonParse.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.pipelineprocessor.functions.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.MissingNode;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
@@ -51,9 +52,9 @@ public class JsonParse extends AbstractFunction<JsonNode> {
         try {
             return objectMapper.readTree(value);
         } catch (IOException e) {
-            log.warn("Unable to parse json", e);
+            log.warn("Unable to parse JSON", e);
         }
-        return null;
+        return MissingNode.getInstance();
     }
 
     @Override

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/SelectJsonPath.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/SelectJsonPath.java
@@ -32,6 +32,7 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
 
 import javax.inject.Inject;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
 import static com.google.common.collect.ImmutableList.of;
@@ -70,7 +71,7 @@ public class SelectJsonPath extends AbstractFunction<Map<String, Object>> {
         final JsonNode json = jsonParam.required(args, context);
         final Map<String, JsonPath> paths = pathsParam.required(args, context);
         if (json == null || paths == null) {
-            return null;
+            return Collections.emptyMap();
         }
         return paths
                 .entrySet().stream()

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/jsonpath.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/jsonpath.txt
@@ -7,4 +7,13 @@ then
               author_last: "$['store']['book'][-1:]['author']"
             });
   set_fields(new_fields);
+
+  // Don't fail on empty input
+  let invalid_json = parse_json("#FOOBAR#");
+  let invalid_json_fields = select_jsonpath(invalid_json, { some_field: "$.message" });
+  set_fields(invalid_json_fields);
+
+  // Don't fail on missing field
+  let missing_fields = select_jsonpath(x, { some_field: "$.i_dont_exist" });
+  set_fields(missing_fields);
 end


### PR DESCRIPTION
The `parse_json()` function is supposed to return a `JsonNode` but returned `null` if the input wasn't valid JSON.

This change set changes the return type to `MissingNode` if the input wasn't valid and couldn't be parsed.

Closes #209