### PR TITLE
Specify type of 'value' (single or multi) for lookup functions.

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/Lookup.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/Lookup.java
@@ -35,7 +35,7 @@ public class Lookup extends AbstractFunction<Map<Object, Object>> {
                 .description("The key to lookup in the table")
                 .build();
         defaultParam = object("default")
-                .description("The default that should be used if there is no lookup result")
+                .description("The default multi value that should be used if there is no lookup result")
                 .optional()
                 .build();
     }
@@ -62,7 +62,7 @@ public class Lookup extends AbstractFunction<Map<Object, Object>> {
         //noinspection unchecked
         return FunctionDescriptor.<Map<Object, Object>>builder()
                 .name(NAME)
-                .description("Looks a value up in the named lookup table.")
+                .description("Looks a multi value up in the named lookup table.")
                 .params(lookupTableParam, keyParam, defaultParam)
                 .returnType((Class<? extends Map<Object, Object>>) new TypeLiteral<Map<Object, Object>>() {}.getRawType())
                 .build();

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/Lookup.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/Lookup.java
@@ -62,7 +62,7 @@ public class Lookup extends AbstractFunction<Map<Object, Object>> {
         //noinspection unchecked
         return FunctionDescriptor.<Map<Object, Object>>builder()
                 .name(NAME)
-                .description("Looks a multi value up in the named lookup table.")
+                .description("Looks up a multi value in the named lookup table.")
                 .params(lookupTableParam, keyParam, defaultParam)
                 .returnType((Class<? extends Map<Object, Object>>) new TypeLiteral<Map<Object, Object>>() {}.getRawType())
                 .build();

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupValue.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupValue.java
@@ -30,7 +30,7 @@ public class LookupValue extends AbstractFunction<Object> {
                 .description("The key to lookup in the table")
                 .build();
         defaultParam = object("default")
-                .description("The default that should be used if there is no lookup result")
+                .description("The default single value that should be used if there is no lookup result")
                 .optional()
                 .build();
     }
@@ -57,7 +57,7 @@ public class LookupValue extends AbstractFunction<Object> {
         //noinspection unchecked
         return FunctionDescriptor.builder()
                 .name(NAME)
-                .description("Looks a value up in the named lookup table.")
+                .description("Looks a single value up in the named lookup table.")
                 .params(lookupTableParam, keyParam, defaultParam)
                 .returnType(Object.class)
                 .build();

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupValue.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupValue.java
@@ -57,7 +57,7 @@ public class LookupValue extends AbstractFunction<Object> {
         //noinspection unchecked
         return FunctionDescriptor.builder()
                 .name(NAME)
-                .description("Looks a single value up in the named lookup table.")
+                .description("Looks up a single value in the named lookup table.")
                 .params(lookupTableParam, keyParam, defaultParam)
                 .returnType(Object.class)
                 .build();


### PR DESCRIPTION
This is intended to make `lookup` and `lookup_value` descriptions a bit more consistent with the Lookup Tables page and documentation.