### PR TITLE
Fix numeric conversions with to_double()/to_long()

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/DoubleConversion.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/DoubleConversion.java
@@ -46,11 +46,15 @@ public class DoubleConversion extends AbstractFunction<Double> {
     public Double evaluate(FunctionArgs args, EvaluationContext context) {
         final Object evaluated = valueParam.required(args, context);
         final Double defaultValue = defaultParam.optional(args, context).orElse(0d);
+
         if (evaluated == null) {
             return defaultValue;
+        } else if (evaluated instanceof Number) {
+            return ((Number) evaluated).doubleValue();
+        } else {
+            final String s = String.valueOf(evaluated);
+            return firstNonNull(Doubles.tryParse(s), defaultValue);
         }
-        return firstNonNull(Doubles.tryParse(evaluated.toString()),
-                            defaultValue);
     }
 
     @Override

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/LongConversion.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/LongConversion.java
@@ -48,7 +48,14 @@ public class LongConversion extends AbstractFunction<Long> {
         final Object evaluated = valueParam.required(args, context);
         final Long defaultValue = defaultParam.optional(args, context).orElse(0L);
 
-        return firstNonNull(tryParse(String.valueOf(evaluated)), defaultValue);
+        if (evaluated == null) {
+            return defaultValue;
+        } else if (evaluated instanceof Number) {
+            return ((Number) evaluated).longValue();
+        } else {
+            final String s = String.valueOf(evaluated);
+            return firstNonNull(tryParse(s), defaultValue);
+        }
     }
 
     @Override

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -652,16 +652,25 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         // special case, Message doesn't allow adding fields with empty string values
         assertThat(message.hasField("string_3")).isFalse();
         assertThat(message.getField("string_4")).isEqualTo("default");
+        assertThat(message.getField("string_5")).isEqualTo("false");
+        assertThat(message.getField("string_6")).isEqualTo("42");
+        assertThat(message.getField("string_7")).isEqualTo("23.42");
 
         assertThat(message.getField("long_1")).isEqualTo(1L);
         assertThat(message.getField("long_2")).isEqualTo(2L);
         assertThat(message.getField("long_3")).isEqualTo(0L);
         assertThat(message.getField("long_4")).isEqualTo(1L);
+        assertThat(message.getField("long_5")).isEqualTo(23L);
+        assertThat(message.getField("long_6")).isEqualTo(23L);
+        assertThat(message.getField("long_7")).isEqualTo(1L);
 
         assertThat(message.getField("double_1")).isEqualTo(1d);
         assertThat(message.getField("double_2")).isEqualTo(2d);
         assertThat(message.getField("double_3")).isEqualTo(0d);
         assertThat(message.getField("double_4")).isEqualTo(1d);
+        assertThat(message.getField("double_5")).isEqualTo(23d);
+        assertThat(message.getField("double_6")).isEqualTo(23d);
+        assertThat(message.getField("double_7")).isEqualTo(23.42d);
 
         assertThat(message.getField("bool_1")).isEqualTo(true);
         assertThat(message.getField("bool_2")).isEqualTo(false);

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -663,6 +663,10 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("long_5")).isEqualTo(23L);
         assertThat(message.getField("long_6")).isEqualTo(23L);
         assertThat(message.getField("long_7")).isEqualTo(1L);
+        assertThat(message.getField("long_min1")).isEqualTo(Long.MIN_VALUE);
+        assertThat(message.getField("long_min2")).isEqualTo(1L);
+        assertThat(message.getField("long_max1")).isEqualTo(Long.MAX_VALUE);
+        assertThat(message.getField("long_max2")).isEqualTo(1L);
 
         assertThat(message.getField("double_1")).isEqualTo(1d);
         assertThat(message.getField("double_2")).isEqualTo(2d);
@@ -671,6 +675,13 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("double_5")).isEqualTo(23d);
         assertThat(message.getField("double_6")).isEqualTo(23d);
         assertThat(message.getField("double_7")).isEqualTo(23.42d);
+        assertThat(message.getField("double_min1")).isEqualTo(Double.MIN_VALUE);
+        assertThat(message.getField("double_min2")).isEqualTo(0d);
+        assertThat(message.getField("double_max1")).isEqualTo(Double.MAX_VALUE);
+        assertThat(message.getField("double_inf1")).isEqualTo(Double.POSITIVE_INFINITY);
+        assertThat(message.getField("double_inf2")).isEqualTo(Double.NEGATIVE_INFINITY);
+        assertThat(message.getField("double_inf3")).isEqualTo(Double.POSITIVE_INFINITY);
+        assertThat(message.getField("double_inf4")).isEqualTo(Double.NEGATIVE_INFINITY);
 
         assertThat(message.getField("bool_1")).isEqualTo(true);
         assertThat(message.getField("bool_2")).isEqualTo(false);

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/conversions.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/conversions.txt
@@ -6,16 +6,25 @@ then
         string_2: to_string("2", "default"),                // "2"
         string_3: to_string($message.not_there),            // "" -> not being set in message!
         string_4: to_string($message.not_there, "default"), // "default"
+        string_5: to_string(false),                         // "false"
+        string_6: to_string(42),                            // "42"
+        string_7: to_string(23.42d),                        // "23.42"
 
         long_1: to_long(1),                     // 1L
         long_2: to_long(2, 1),                  // 2L
         long_3: to_long($message.not_there),    // 0L
         long_4: to_long($message.not_there, 1), // 1L
+        long_5: to_long(23.42d),                // 23L
+        long_6: to_long("23"),                  // 23L
+        long_7: to_long("23.42", 1),            // 1L
 
         double_1: to_double(1d),                        // 1d
         double_2: to_double(2d, 1d),                    // 2d
         double_3: to_double($message.not_there),        // 0d
         double_4: to_double($message.not_there, 1d),    // 1d
+        double_5: to_double(23),                        // 23d
+        double_6: to_double("23"),                      // 23d
+        double_7: to_double("23.42"),                   // 23.42d
 
         bool_1: to_bool("true"),                      // true
         bool_2: to_bool("false", true),               // false

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/conversions.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/conversions.txt
@@ -10,21 +10,32 @@ then
         string_6: to_string(42),                            // "42"
         string_7: to_string(23.42d),                        // "23.42"
 
-        long_1: to_long(1),                     // 1L
-        long_2: to_long(2, 1),                  // 2L
-        long_3: to_long($message.not_there),    // 0L
-        long_4: to_long($message.not_there, 1), // 1L
-        long_5: to_long(23.42d),                // 23L
-        long_6: to_long("23"),                  // 23L
-        long_7: to_long("23.42", 1),            // 1L
+        long_1: to_long(1),                            // 1L
+        long_2: to_long(2, 1),                         // 2L
+        long_3: to_long($message.not_there),           // 0L
+        long_4: to_long($message.not_there, 1),        // 1L
+        long_5: to_long(23.42d),                       // 23L
+        long_6: to_long("23"),                         // 23L
+        long_7: to_long("23.42", 1),                   // 1L
+        long_min1: to_long("-9223372036854775808", 1), // Long.MIN_VALUE
+        long_min2: to_long("-9223372036854775809", 1), // 1L
+        long_max1: to_long("9223372036854775807", 1),  // Long.MAX_VALUE
+        long_max2: to_long("9223372036854775808", 1),  // 1L
 
-        double_1: to_double(1d),                        // 1d
-        double_2: to_double(2d, 1d),                    // 2d
-        double_3: to_double($message.not_there),        // 0d
-        double_4: to_double($message.not_there, 1d),    // 1d
-        double_5: to_double(23),                        // 23d
-        double_6: to_double("23"),                      // 23d
-        double_7: to_double("23.42"),                   // 23.42d
+        double_1: to_double(1d),                               // 1d
+        double_2: to_double(2d, 1d),                           // 2d
+        double_3: to_double($message.not_there),               // 0d
+        double_4: to_double($message.not_there, 1d),           // 1d
+        double_5: to_double(23),                               // 23d
+        double_6: to_double("23"),                             // 23d
+        double_7: to_double("23.42"),                          // 23.42d
+        double_min1: to_double("4.9E-324"),                    // Double.MIN_VALUE
+        double_min2: to_double("4.9E-325", 1d),                // 0d
+        double_max1: to_double("1.7976931348623157E308"),      // Double.MAX_VALUE
+        double_inf1: to_double("1.7976931348623157E309", 1d),  // Infinity
+        double_inf2: to_double("-1.7976931348623157E309", 1d), // -Infinity
+        double_inf3: to_double("Infinity", 1d),                // Infinity
+        double_inf4: to_double("-Infinity", 1d),               // -Infinity
 
         bool_1: to_bool("true"),                      // true
         bool_2: to_bool("false", true),               // false


### PR DESCRIPTION
The functions for numeric conversions, `to_long()` and `to_double()`, didn't properly support converting from strings or other numeric types.

Refs https://community.graylog.org/t/graylog-pipeline-problem/2810