### PR TITLE
add remove_from_default boolean option to route_to_stream function

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -46,8 +46,6 @@ import org.graylog.plugins.pipelineprocessor.functions.encoding.Base32Decode;
 import org.graylog.plugins.pipelineprocessor.functions.encoding.Base32Encode;
 import org.graylog.plugins.pipelineprocessor.functions.encoding.Base32HumanDecode;
 import org.graylog.plugins.pipelineprocessor.functions.encoding.Base32HumanEncode;
-import org.graylog.plugins.pipelineprocessor.functions.encoding.Base64Decode;
-import org.graylog.plugins.pipelineprocessor.functions.encoding.Base64Encode;
 import org.graylog.plugins.pipelineprocessor.functions.encoding.Base64UrlDecode;
 import org.graylog.plugins.pipelineprocessor.functions.encoding.Base64UrlEncode;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.CRC32;
@@ -69,6 +67,7 @@ import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.DropMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.HasField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveField;
+import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveFromStream;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RenameField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RouteToStream;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
@@ -113,6 +112,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(DropMessage.NAME, DropMessage.class);
         addMessageProcessorFunction(CreateMessage.NAME, CreateMessage.class);
         addMessageProcessorFunction(CloneMessage.NAME, CloneMessage.class);
+        addMessageProcessorFunction(RemoveFromStream.NAME, RemoveFromStream.class);
         addMessageProcessorFunction(RouteToStream.NAME, RouteToStream.class);
         // helper service for route_to_stream
         serviceBinder().addBinding().to(StreamCacheService.class).in(Scopes.SINGLETON);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/RemoveFromStream.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/RemoveFromStream.java
@@ -1,0 +1,105 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.messages;
+
+import com.google.inject.Inject;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.streams.DefaultStream;
+import org.graylog2.plugin.streams.Stream;
+
+import javax.inject.Provider;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.of;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.type;
+
+public class RemoveFromStream extends AbstractFunction<Void> {
+
+    public static final String NAME = "remove_from_stream";
+    private static final String ID_ARG = "id";
+    private static final String NAME_ARG = "name";
+    private final StreamCacheService streamCacheService;
+    private final Provider<Stream> defaultStreamProvider;
+    private final ParameterDescriptor<Message, Message> messageParam;
+    private final ParameterDescriptor<String, String> nameParam;
+    private final ParameterDescriptor<String, String> idParam;
+
+    @Inject
+    public RemoveFromStream(StreamCacheService streamCacheService, @DefaultStream Provider<Stream> defaultStreamProvider) {
+        this.streamCacheService = streamCacheService;
+        this.defaultStreamProvider = defaultStreamProvider;
+
+        messageParam = type("message", Message.class).optional().description("The message to use, defaults to '$message'").build();
+        nameParam = string(NAME_ARG).optional().description("The name of the stream to remove the message from, must match exactly").build();
+        idParam = string(ID_ARG).optional().description("The ID of the stream").build();
+    }
+
+    @Override
+    public Void evaluate(FunctionArgs args, EvaluationContext context) {
+        Optional<String> id = idParam.optional(args, context);
+
+        Collection<Stream> streams;
+        if (!id.isPresent()) {
+            final Optional<Collection<Stream>> foundStreams = nameParam.optional(args, context).map(streamCacheService::getByName);
+
+            if (!foundStreams.isPresent()) {
+                // TODO signal error somehow
+                return null;
+            } else {
+                streams = foundStreams.get();
+            }
+        } else {
+            final Stream stream = streamCacheService.getById(id.get());
+            if (stream == null) {
+                return null;
+            }
+            streams = Collections.singleton(stream);
+        }
+        final Message message = messageParam.optional(args, context).orElse(context.currentMessage());
+        streams.forEach(stream -> {
+            if (!stream.isPaused()) {
+                message.removeStream(stream);
+            }
+        });
+        // always leave a message at least on the default stream if we removed the last stream it was on
+        if (message.getStreams().isEmpty()) {
+            message.addStream(defaultStreamProvider.get());
+        }
+        return null;
+    }
+
+    @Override
+    public FunctionDescriptor<Void> descriptor() {
+        return FunctionDescriptor.<Void>builder()
+                .name(NAME)
+                .returnType(Void.class)
+                .params(of(
+                        nameParam,
+                        idParam,
+                        messageParam))
+                .description("Removes a message from a stream. Removing the last stream will put the message back onto the default stream. To complete drop a message use the drop_message function.")
+                .build();
+    }
+}

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeFromStream.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeFromStream.txt
@@ -1,0 +1,5 @@
+rule "stream routing"
+when true
+then
+    remove_from_stream(name: "some name");
+end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeFromStreamRetainDefault.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeFromStreamRetainDefault.txt
@@ -1,0 +1,7 @@
+rule "stream routing"
+when true
+then
+    remove_from_stream(name: "some name");
+    // if a message is taken off all stream it was on, the default stream will be added back to avoid dropping the message
+    remove_from_stream(id: "000000000000000000000001");
+end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/routeToStreamRemoveDefault.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/routeToStreamRemoveDefault.txt
@@ -1,0 +1,5 @@
+rule "stream routing"
+when true
+then
+    route_to_stream(name: "some name", remove_from_default: true);
+end


### PR DESCRIPTION
this allows remove messages from the default stream like the stream router already does

with the `remove_from_stream` function any arbitrary stream can be removed. it always makes sure that the message is at least on the default stream. dropping messages this way is not supported, the user must use `drop_message` for that purpose.

fixes #117 