### PR TITLE
Add `starts_with` and `ends_with` string functions

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -79,11 +79,13 @@ import org.graylog.plugins.pipelineprocessor.functions.strings.Abbreviate;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Capitalize;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Concat;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Contains;
+import org.graylog.plugins.pipelineprocessor.functions.strings.EndsWith;
 import org.graylog.plugins.pipelineprocessor.functions.strings.GrokMatch;
 import org.graylog.plugins.pipelineprocessor.functions.strings.KeyValue;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Lowercase;
 import org.graylog.plugins.pipelineprocessor.functions.strings.RegexMatch;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Split;
+import org.graylog.plugins.pipelineprocessor.functions.strings.StartsWith;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Substring;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Swapcase;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Uncapitalize;
@@ -130,6 +132,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(Abbreviate.NAME, Abbreviate.class);
         addMessageProcessorFunction(Capitalize.NAME, Capitalize.class);
         addMessageProcessorFunction(Contains.NAME, Contains.class);
+        addMessageProcessorFunction(EndsWith.NAME, EndsWith.class);
         addMessageProcessorFunction(Lowercase.NAME, Lowercase.class);
         addMessageProcessorFunction(Substring.NAME, Substring.class);
         addMessageProcessorFunction(Swapcase.NAME, Swapcase.class);
@@ -138,6 +141,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(Concat.NAME, Concat.class);
         addMessageProcessorFunction(KeyValue.NAME, KeyValue.class);
         addMessageProcessorFunction(Split.NAME, Split.class);
+        addMessageProcessorFunction(StartsWith.NAME, StartsWith.class);
 
         // json
         addMessageProcessorFunction(JsonParse.NAME, JsonParse.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/EndsWith.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/EndsWith.java
@@ -1,0 +1,66 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.strings;
+
+import org.apache.commons.lang3.StringUtils;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class EndsWith extends AbstractFunction<Boolean> {
+
+    public static final String NAME = "ends_with";
+    private final ParameterDescriptor<String, String> valueParam;
+    private final ParameterDescriptor<String, String> suffixParam;
+    private final ParameterDescriptor<Boolean, Boolean> ignoreCaseParam;
+
+    public EndsWith() {
+        valueParam = ParameterDescriptor.string("value").description("The string to check").build();
+        suffixParam = ParameterDescriptor.string("suffix").description("The suffix to check").build();
+        ignoreCaseParam = ParameterDescriptor.bool("ignore_case").optional().description("Whether to search case insensitive, defaults to false").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final String value = valueParam.required(args, context);
+        final String suffix = suffixParam.required(args, context);
+        final boolean ignoreCase = ignoreCaseParam.optional(args, context).orElse(false);
+        if (ignoreCase) {
+            return StringUtils.endsWithIgnoreCase(value, suffix);
+        } else {
+            return StringUtils.endsWith(value, suffix);
+        }
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(of(
+                        valueParam,
+                        suffixParam,
+                        ignoreCaseParam
+                ))
+                .description("Checks if a string ends with a suffix")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/StartsWith.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/StartsWith.java
@@ -1,0 +1,66 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.strings;
+
+import org.apache.commons.lang3.StringUtils;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class StartsWith extends AbstractFunction<Boolean> {
+
+    public static final String NAME = "starts_with";
+    private final ParameterDescriptor<String, String> valueParam;
+    private final ParameterDescriptor<String, String> prefixParam;
+    private final ParameterDescriptor<Boolean, Boolean> ignoreCaseParam;
+
+    public StartsWith() {
+        valueParam = ParameterDescriptor.string("value").description("The string to check").build();
+        prefixParam = ParameterDescriptor.string("prefix").description("The prefix to check").build();
+        ignoreCaseParam = ParameterDescriptor.bool("ignore_case").optional().description("Whether to search case insensitive, defaults to false").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final String value = valueParam.required(args, context);
+        final String prefix = prefixParam.required(args, context);
+        final boolean ignoreCase = ignoreCaseParam.optional(args, context).orElse(false);
+        if (ignoreCase) {
+            return StringUtils.startsWithIgnoreCase(value, prefix);
+        } else {
+            return StringUtils.startsWith(value, prefix);
+        }
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(of(
+                        valueParam,
+                        prefixParam,
+                        ignoreCaseParam
+                ))
+                .description("Checks if a string starts with a prefix")
+                .build();
+    }
+}

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -83,11 +83,13 @@ import org.graylog.plugins.pipelineprocessor.functions.strings.Abbreviate;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Capitalize;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Concat;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Contains;
+import org.graylog.plugins.pipelineprocessor.functions.strings.EndsWith;
 import org.graylog.plugins.pipelineprocessor.functions.strings.GrokMatch;
 import org.graylog.plugins.pipelineprocessor.functions.strings.KeyValue;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Lowercase;
 import org.graylog.plugins.pipelineprocessor.functions.strings.RegexMatch;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Split;
+import org.graylog.plugins.pipelineprocessor.functions.strings.StartsWith;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Substring;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Swapcase;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Uncapitalize;
@@ -192,6 +194,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(Capitalize.NAME, new Capitalize());
         functions.put(Concat.NAME, new Concat());
         functions.put(Contains.NAME, new Contains());
+        functions.put(EndsWith.NAME, new EndsWith());
         functions.put(Lowercase.NAME, new Lowercase());
         functions.put(Substring.NAME, new Substring());
         functions.put(Swapcase.NAME, new Swapcase());
@@ -199,6 +202,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(Uppercase.NAME, new Uppercase());
         functions.put(KeyValue.NAME, new KeyValue());
         functions.put(Split.NAME, new Split());
+        functions.put(StartsWith.NAME, new StartsWith());
 
         final ObjectMapper objectMapper = new ObjectMapperProvider().get();
         functions.put(JsonParse.NAME, new JsonParse(objectMapper));

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/strings.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/strings.txt
@@ -14,7 +14,19 @@ when
     abbreviate("abcdefg", 7) == "abcdefg" &&
     abbreviate("abcdefg", 8) == "abcdefg" &&
     abbreviate("abcdefg", 4) == "a..." &&
-    concat("foo", "bar") == "foobar"
+    concat("foo", "bar") == "foobar" &&
+    starts_with("foobar", "foo") == true &&
+    starts_with("foobar", "") == true &&
+    starts_with("", "foo") == false &&
+    starts_with("foobar", "abc") == false &&
+    starts_with("foobar", "FOO") == false &&
+    starts_with("foobar", "FOO", true) == true &&
+    ends_with("foobar", "bar") == true &&
+    ends_with("foobar", "") == true &&
+    ends_with("", "bar") == false &&
+    ends_with("foobar", "abc") == false &&
+    ends_with("foobar", "BAR") == false &&
+    ends_with("foobar", "BAR", true) == true
 then
     set_field("has_xyz", contains("abcdef", "xyz"));
     set_field("string_literal", "abcd\\.e\tfg\u03a9\363");


### PR DESCRIPTION
This PR adds the commonly required `starts_with()` and `ends_with()` string functions to check a string prefix or suffix respectively without having to use regular expressions (which might be less performant).