### PR TITLE
Add support for JsonNode to ´set_fields()`

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -24,6 +24,7 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.BooleanConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.DoubleConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.LongConversion;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.MapConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
 import org.graylog.plugins.pipelineprocessor.functions.dates.DateConversion;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FlexParseDate;
@@ -103,6 +104,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(DoubleConversion.NAME, DoubleConversion.class);
         addMessageProcessorFunction(LongConversion.NAME, LongConversion.class);
         addMessageProcessorFunction(StringConversion.NAME, StringConversion.class);
+        addMessageProcessorFunction(MapConversion.NAME, MapConversion.class);
 
         // message related functions
         addMessageProcessorFunction(HasField.NAME, HasField.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/MapConversion.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/MapConversion.java
@@ -40,7 +40,7 @@ public class MapConversion extends AbstractFunction<Map> {
 
 
     public MapConversion() {
-        this.valueParam = object(VALUE).description("Value to convert").build();
+        this.valueParam = object(VALUE).description("Map-like value to convert").build();
     }
 
     @Override
@@ -65,7 +65,7 @@ public class MapConversion extends AbstractFunction<Map> {
                 .name(NAME)
                 .returnType(Map.class)
                 .params(of(valueParam))
-                .description("Converts a value to a long value using its string representation")
+                .description("Converts a map-like value into a map usable by set_fields()")
                 .build();
     }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/MapConversion.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/MapConversion.java
@@ -1,0 +1,71 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.conversion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableList.of;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class MapConversion extends AbstractFunction<Map> {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public static final String NAME = "to_map";
+    private static final String VALUE = "value";
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+
+    public MapConversion() {
+        this.valueParam = object(VALUE).description("Value to convert").build();
+    }
+
+    @Override
+    public Map evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+
+        if (value == null) {
+            return Collections.emptyMap();
+        } else if (value instanceof Map) {
+            return (Map) value;
+        } else if (value instanceof JsonNode) {
+            final JsonNode jsonNode = (JsonNode) value;
+            return MAPPER.convertValue(jsonNode, Map.class);
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    @Override
+    public FunctionDescriptor<Map> descriptor() {
+        return FunctionDescriptor.<Map>builder()
+                .name(NAME)
+                .returnType(Map.class)
+                .params(of(valueParam))
+                .description("Converts a value to a long value using its string representation")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/SetFields.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/SetFields.java
@@ -16,8 +16,6 @@
  */
 package org.graylog.plugins.pipelineprocessor.functions.messages;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
@@ -27,7 +25,6 @@ import org.graylog2.plugin.Message;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 
 import static com.google.common.collect.ImmutableList.of;
 import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
@@ -37,16 +34,13 @@ public class SetFields extends AbstractFunction<Void> {
 
     public static final String NAME = "set_fields";
 
-    private final ParameterDescriptor<Object, Map> fieldsParam;
+    private final ParameterDescriptor<Map, Map> fieldsParam;
     private final ParameterDescriptor<String, String> prefixParam;
     private final ParameterDescriptor<String, String> suffixParam;
     private final ParameterDescriptor<Message, Message> messageParam;
 
     public SetFields() {
-        fieldsParam = type("fields", Object.class, Map.class)
-                .description("The map of new fields to set")
-                .transform(new MapTransformer())
-                .build();
+        fieldsParam = type("fields", Map.class).description("The map of new fields to set").build();
         prefixParam = string("prefix").optional().description("The prefix for the field names").build();
         suffixParam = string("suffix").optional().description("The suffix for the field names").build();
         messageParam = type("message", Message.class).optional().description("The message to use, defaults to '$message'").build();
@@ -54,7 +48,8 @@ public class SetFields extends AbstractFunction<Void> {
 
     @Override
     public Void evaluate(FunctionArgs args, EvaluationContext context) {
-        @SuppressWarnings("unchecked") final Map<String, Object> fields = fieldsParam.required(args, context);
+        //noinspection unchecked
+        final Map<String, Object> fields = fieldsParam.required(args, context);
         final Message message = messageParam.optional(args, context).orElse(context.currentMessage());
         final Optional<String> prefix = prefixParam.optional(args, context);
         final Optional<String> suffix = suffixParam.optional(args, context);
@@ -83,27 +78,4 @@ public class SetFields extends AbstractFunction<Void> {
                 .build();
     }
 
-    private static class MapTransformer implements Function<Object, Map> {
-        private final ObjectMapper objectMapper;
-
-        public MapTransformer(ObjectMapper objectMapper) {
-            this.objectMapper = objectMapper;
-        }
-
-        public MapTransformer() {
-            this(new ObjectMapper());
-        }
-
-        @Override
-        public Map apply(Object o) {
-            if (o instanceof Map) {
-                return (Map) o;
-            } else if (o instanceof JsonNode) {
-                final JsonNode jsonNode = (JsonNode) o;
-                return objectMapper.convertValue(jsonNode, Map.class);
-            } else {
-                return null;
-            }
-        }
-    }
 }

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/SetFields.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/SetFields.java
@@ -16,6 +16,8 @@
  */
 package org.graylog.plugins.pipelineprocessor.functions.messages;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
@@ -25,6 +27,7 @@ import org.graylog2.plugin.Message;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static com.google.common.collect.ImmutableList.of;
 import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
@@ -34,13 +37,16 @@ public class SetFields extends AbstractFunction<Void> {
 
     public static final String NAME = "set_fields";
 
-    private final ParameterDescriptor<Map, Map> fieldsParam;
+    private final ParameterDescriptor<Object, Map> fieldsParam;
     private final ParameterDescriptor<String, String> prefixParam;
     private final ParameterDescriptor<String, String> suffixParam;
     private final ParameterDescriptor<Message, Message> messageParam;
 
     public SetFields() {
-        fieldsParam = type("fields", Map.class).description("The map of new fields to set").build();
+        fieldsParam = type("fields", Object.class, Map.class)
+                .description("The map of new fields to set")
+                .transform(new MapTransformer())
+                .build();
         prefixParam = string("prefix").optional().description("The prefix for the field names").build();
         suffixParam = string("suffix").optional().description("The suffix for the field names").build();
         messageParam = type("message", Message.class).optional().description("The message to use, defaults to '$message'").build();
@@ -48,8 +54,7 @@ public class SetFields extends AbstractFunction<Void> {
 
     @Override
     public Void evaluate(FunctionArgs args, EvaluationContext context) {
-        //noinspection unchecked
-        final Map<String, Object> fields = fieldsParam.required(args, context);
+        @SuppressWarnings("unchecked") final Map<String, Object> fields = fieldsParam.required(args, context);
         final Message message = messageParam.optional(args, context).orElse(context.currentMessage());
         final Optional<String> prefix = prefixParam.optional(args, context);
         final Optional<String> suffix = suffixParam.optional(args, context);
@@ -78,4 +83,27 @@ public class SetFields extends AbstractFunction<Void> {
                 .build();
     }
 
+    private static class MapTransformer implements Function<Object, Map> {
+        private final ObjectMapper objectMapper;
+
+        public MapTransformer(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
+
+        public MapTransformer() {
+            this(new ObjectMapper());
+        }
+
+        @Override
+        public Map apply(Object o) {
+            if (o instanceof Map) {
+                return (Map) o;
+            } else if (o instanceof JsonNode) {
+                final JsonNode jsonNode = (JsonNode) o;
+                return objectMapper.convertValue(jsonNode, Map.class);
+            } else {
+                return null;
+            }
+        }
+    }
 }

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -119,6 +119,7 @@ import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 
 import javax.inject.Provider;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -317,6 +318,43 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("author_first")).isEqualTo("Nigel Rees");
         assertThat(message.hasField("author_last")).isTrue();
         assertThat(message.hasField("this_should_exist")).isTrue();
+    }
+
+    @Test
+    public void json() {
+        final String flatJson = "{\"str\":\"foobar\",\"int\":42,\"float\":2.5,\"bool\":true,\"array\":[1,2,3]}";
+        final String nestedJson = "{\n" +
+                "    \"store\": {\n" +
+                "        \"book\": {\n" +
+                "            \"category\": \"reference\",\n" +
+                "            \"author\": \"Nigel Rees\",\n" +
+                "            \"title\": \"Sayings of the Century\",\n" +
+                "            \"price\": 8.95\n" +
+                "        },\n" +
+                "        \"bicycle\": {\n" +
+                "            \"color\": \"red\",\n" +
+                "            \"price\": 19.95\n" +
+                "        }\n" +
+                "    },\n" +
+                "    \"expensive\": 10\n" +
+                "}";
+
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final Message message = new Message("JSON", "test", Tools.nowUTC());
+        message.addField("flat_json", flatJson);
+        message.addField("nested_json", nestedJson);
+        final Message evaluatedMessage = evaluateRule(rule, message);
+
+        assertThat(evaluatedMessage.getField("message")).isEqualTo("JSON");
+        assertThat(evaluatedMessage.getField("flat_json")).isEqualTo(flatJson);
+        assertThat(evaluatedMessage.getField("nested_json")).isEqualTo(nestedJson);
+        assertThat(evaluatedMessage.getField("str")).isEqualTo("foobar");
+        assertThat(evaluatedMessage.getField("int")).isEqualTo(42);
+        assertThat(evaluatedMessage.getField("float")).isEqualTo(2.5);
+        assertThat(evaluatedMessage.getField("bool")).isEqualTo(true);
+        assertThat(evaluatedMessage.getField("array")).isEqualTo(Arrays.asList(1, 2, 3));
+        assertThat(evaluatedMessage.getField("store")).isInstanceOf(Map.class);
+        assertThat(evaluatedMessage.getField("expensive")).isEqualTo(10);
     }
 
     @Test

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -30,6 +30,7 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.BooleanConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.DoubleConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.LongConversion;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.MapConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
 import org.graylog.plugins.pipelineprocessor.functions.dates.DateConversion;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FlexParseDate;
@@ -120,6 +121,7 @@ import org.mockito.ArgumentMatchers;
 
 import javax.inject.Provider;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -147,6 +149,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(DoubleConversion.NAME, new DoubleConversion());
         functions.put(LongConversion.NAME, new LongConversion());
         functions.put(StringConversion.NAME, new StringConversion());
+        functions.put(MapConversion.NAME, new MapConversion());
 
         // message related functions
         functions.put(HasField.NAME, new HasField());
@@ -732,6 +735,12 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("ip_3")).isEqualTo(new IpAddress(InetAddresses.forString("0.0.0.0")));
         assertThat(message.getField("ip_4")).isEqualTo(new IpAddress(InetAddresses.forString("::1")));
 
+        assertThat(message.getField("map_1")).isEqualTo(Collections.singletonMap("foo", "bar"));
+        assertThat(message.getField("map_2")).isEqualTo(Collections.emptyMap());
+        assertThat(message.getField("map_3")).isEqualTo(Collections.emptyMap());
+        assertThat(message.getField("map_4")).isEqualTo(Collections.emptyMap());
+        assertThat(message.getField("map_5")).isEqualTo(Collections.emptyMap());
+        assertThat(message.getField("map_6")).isEqualTo(Collections.emptyMap());
     }
 
     @Test

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/conversions.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/conversions.txt
@@ -45,6 +45,13 @@ then
         ip_1: to_ip("127.0.0.1"),                 // 127.0.0.1
         ip_2: to_ip("127.0.0.1", "2001:db8::1"),  // 127.0.0.1
         ip_3: to_ip($message.not_there),          // 0.0.0.0
-        ip_4: to_ip($message.not_there, "::1")    // ::1 (v6)
+        ip_4: to_ip($message.not_there, "::1"),   // ::1 (v6)
+
+        map_1: to_map({foo:"bar"}),       // Map.of("foo", "bar")
+        map_2: to_map("foobar"),          // empty map
+        map_3: to_map(23),                // empty map
+        map_4: to_map(23.42),             // empty map
+        map_5: to_map(true),              // empty map
+        map_6: to_map($message.not_there) // empty map
     });
 end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/json.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/json.txt
@@ -1,0 +1,19 @@
+rule "json"
+when
+  true
+then
+  let json = parse_json(to_string($message.flat_json));
+  set_fields(json);
+
+  // Don't fail on invalid input
+  let invalid_json = parse_json("#FOOBAR#");
+  set_fields(invalid_json);
+
+  // Don't fail on empty input
+  let empty_json = parse_json("");
+  set_fields(empty_json);
+
+  // Don't fail on nested input
+  let nested_json = parse_json(to_string($message.nested_json));
+  set_fields(nested_json);
+end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/json.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/json.txt
@@ -3,17 +3,17 @@ when
   true
 then
   let json = parse_json(to_string($message.flat_json));
-  set_fields(json);
+  set_fields(to_map(json));
 
   // Don't fail on invalid input
   let invalid_json = parse_json("#FOOBAR#");
-  set_fields(invalid_json);
+  set_fields(to_map(invalid_json));
 
   // Don't fail on empty input
   let empty_json = parse_json("");
-  set_fields(empty_json);
+  set_fields(to_map(empty_json));
 
   // Don't fail on nested input
   let nested_json = parse_json(to_string($message.nested_json));
-  set_fields(nested_json);
+  set_fields(to_map(nested_json));
 end


### PR DESCRIPTION
Sometimes users might want to parse and merge the JSON payload of a message
with the Graylog message without knowing the complete structure of the payload
or without having a fixed structure which could be selectively merged by using
the `json_path()` method.

This commit essentially adds the possiblity to create a pipeline rule emulating
the existing JSON extractor:

    rule "json"
    when
      // some condition
    then
      let json = parse_json(to_string($message.some_field));
      set_fields(json);
    end

Refs: https://community.graylog.org/t/parse-unknown-json-with-pipelines/3293/7