### PR TITLE
Add comparison functions for all supported types

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -23,15 +23,25 @@ import com.google.inject.multibindings.MapBinder;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.BooleanConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.DoubleConversion;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsBoolean;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsCollection;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsDouble;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsList;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsLong;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsMap;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsNumber;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsString;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.LongConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
 import org.graylog.plugins.pipelineprocessor.functions.dates.DateConversion;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FlexParseDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FormatDate;
+import org.graylog.plugins.pipelineprocessor.functions.dates.IsDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.Now;
 import org.graylog.plugins.pipelineprocessor.functions.dates.ParseDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Days;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Hours;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.IsPeriod;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Millis;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Minutes;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Months;
@@ -60,6 +70,8 @@ import org.graylog.plugins.pipelineprocessor.functions.hashing.SHA256;
 import org.graylog.plugins.pipelineprocessor.functions.hashing.SHA512;
 import org.graylog.plugins.pipelineprocessor.functions.ips.CidrMatch;
 import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
+import org.graylog.plugins.pipelineprocessor.functions.ips.IsIp;
+import org.graylog.plugins.pipelineprocessor.functions.json.IsJson;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.Lookup;
@@ -92,6 +104,7 @@ import org.graylog.plugins.pipelineprocessor.functions.syslog.SyslogFacilityConv
 import org.graylog.plugins.pipelineprocessor.functions.syslog.SyslogLevelConversion;
 import org.graylog.plugins.pipelineprocessor.functions.syslog.SyslogPriorityConversion;
 import org.graylog.plugins.pipelineprocessor.functions.syslog.SyslogPriorityToStringConversion;
+import org.graylog.plugins.pipelineprocessor.functions.urls.IsUrl;
 import org.graylog.plugins.pipelineprocessor.functions.urls.UrlConversion;
 import org.graylog2.plugin.PluginModule;
 
@@ -103,6 +116,21 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(DoubleConversion.NAME, DoubleConversion.class);
         addMessageProcessorFunction(LongConversion.NAME, LongConversion.class);
         addMessageProcessorFunction(StringConversion.NAME, StringConversion.class);
+
+        // Comparison functions
+        addMessageProcessorFunction(IsBoolean.NAME, IsBoolean.class);
+        addMessageProcessorFunction(IsNumber.NAME, IsNumber.class);
+        addMessageProcessorFunction(IsDouble.NAME, IsDouble.class);
+        addMessageProcessorFunction(IsLong.NAME, IsLong.class);
+        addMessageProcessorFunction(IsString.NAME, IsString.class);
+        addMessageProcessorFunction(IsCollection.NAME, IsCollection.class);
+        addMessageProcessorFunction(IsList.NAME, IsList.class);
+        addMessageProcessorFunction(IsMap.NAME, IsMap.class);
+        addMessageProcessorFunction(IsDate.NAME, IsDate.class);
+        addMessageProcessorFunction(IsPeriod.NAME, IsPeriod.class);
+        addMessageProcessorFunction(IsIp.NAME, IsIp.class);
+        addMessageProcessorFunction(IsJson.NAME, IsJson.class);
+        addMessageProcessorFunction(IsUrl.NAME, IsUrl.class);
 
         // message related functions
         addMessageProcessorFunction(HasField.NAME, HasField.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsBoolean.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsBoolean.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.conversion;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class IsBoolean extends AbstractFunction<Boolean> {
+    public static final String NAME = "is_bool";
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    public IsBoolean() {
+        valueParam = object("value").description("Value to check").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+        return value instanceof Boolean;
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(valueParam)
+                .description("Checks whether a value is a boolean")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsCollection.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsCollection.java
@@ -1,0 +1,53 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.conversion;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.Collection;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class IsCollection extends AbstractFunction<Boolean> {
+    public static final String NAME = "is_collection";
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    public IsCollection() {
+        valueParam = object("value").description("Value to check").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+        return value instanceof Collection;
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(valueParam)
+                .description("Checks whether a value is a collection")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsDouble.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsDouble.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.conversion;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class IsDouble extends AbstractFunction<Boolean> {
+    public static final String NAME = "is_double";
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    public IsDouble() {
+        valueParam = object("value").description("Value to check").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+        return value instanceof Double;
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(valueParam)
+                .description("Checks whether a value is a double")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsList.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsList.java
@@ -1,0 +1,53 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.conversion;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.List;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class IsList extends AbstractFunction<Boolean> {
+    public static final String NAME = "is_list";
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    public IsList() {
+        valueParam = object("value").description("Value to check").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+        return value instanceof List;
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(valueParam)
+                .description("Checks whether a value is a list")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsLong.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsLong.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.conversion;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class IsLong extends AbstractFunction<Boolean> {
+    public static final String NAME = "is_long";
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    public IsLong() {
+        valueParam = object("value").description("Value to check").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+        return value instanceof Long;
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(valueParam)
+                .description("Checks whether a value is a long integer")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsMap.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsMap.java
@@ -1,0 +1,53 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.conversion;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import java.util.Map;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class IsMap extends AbstractFunction<Boolean> {
+    public static final String NAME = "is_map";
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    public IsMap() {
+        valueParam = object("value").description("Value to check").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+        return value instanceof Map;
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(valueParam)
+                .description("Checks whether a value is a map")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsNumber.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsNumber.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.conversion;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class IsNumber extends AbstractFunction<Boolean> {
+    public static final String NAME = "is_number";
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    public IsNumber() {
+        valueParam = object("value").description("Value to check").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+        return value instanceof Number;
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(valueParam)
+                .description("Checks whether a value is a number")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsString.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/IsString.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.conversion;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class IsString extends AbstractFunction<Boolean> {
+    public static final String NAME = "is_string";
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    public IsString() {
+        valueParam = object("value").description("Value to check").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+        return value instanceof String;
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(valueParam)
+                .description("Checks whether a value is a string")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/IsDate.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/IsDate.java
@@ -1,0 +1,54 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.dates;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.joda.time.DateTime;
+
+import java.util.Date;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class IsDate extends AbstractFunction<Boolean> {
+    public static final String NAME = "is_date";
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    public IsDate() {
+        valueParam = object("value").description("Value to check").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+        return value instanceof Date || value instanceof DateTime;
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(valueParam)
+                .description("Checks whether a value is a date")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/IsPeriod.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/periods/IsPeriod.java
@@ -1,0 +1,52 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.dates.periods;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.joda.time.Period;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class IsPeriod extends AbstractFunction<Boolean> {
+    public static final String NAME = "is_period";
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    public IsPeriod() {
+        valueParam = object("value").description("Value to check").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+        return value instanceof Period;
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(valueParam)
+                .description("Checks whether a value is a time period")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IsIp.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IsIp.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.ips;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class IsIp extends AbstractFunction<Boolean> {
+    public static final String NAME = "is_ip";
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    public IsIp() {
+        valueParam = object("value").description("Value to check").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+        return value instanceof IpAddress;
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(valueParam)
+                .description("Checks whether a value is an IP address")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/IsJson.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/IsJson.java
@@ -1,0 +1,52 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class IsJson extends AbstractFunction<Boolean> {
+    public static final String NAME = "is_json";
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    public IsJson() {
+        valueParam = object("value").description("Value to check").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+        return value instanceof JsonNode;
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(valueParam)
+                .description("Checks whether a value is a JSON value")
+                .build();
+    }
+}

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/urls/IsUrl.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/urls/IsUrl.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.urls;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+
+public class IsUrl extends AbstractFunction<Boolean> {
+    public static final String NAME = "is_url";
+
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    public IsUrl() {
+        valueParam = object("value").description("Value to check").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final Object value = valueParam.required(args, context);
+        return value instanceof URL;
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+        return FunctionDescriptor.<Boolean>builder()
+                .name(NAME)
+                .returnType(Boolean.class)
+                .params(valueParam)
+                .description("Checks whether a value is a URL")
+                .build();
+    }
+}

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -670,6 +670,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         final EvaluationContext context = contextForRuleEval(rule, new Message("", "", Tools.nowUTC()));
         assertThat(context.hasEvaluationErrors()).isFalse();
         assertThat(evaluateRule(rule)).isNotNull();
+        assertThat(actionsTriggered.get()).isTrue();
     }
 
     @Test

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -29,15 +29,25 @@ import org.graylog.plugins.pipelineprocessor.ast.Rule;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.BooleanConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.DoubleConversion;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsBoolean;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsCollection;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsDouble;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsList;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsLong;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsMap;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsNumber;
+import org.graylog.plugins.pipelineprocessor.functions.conversion.IsString;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.LongConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.StringConversion;
 import org.graylog.plugins.pipelineprocessor.functions.dates.DateConversion;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FlexParseDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FormatDate;
+import org.graylog.plugins.pipelineprocessor.functions.dates.IsDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.Now;
 import org.graylog.plugins.pipelineprocessor.functions.dates.ParseDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Days;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Hours;
+import org.graylog.plugins.pipelineprocessor.functions.dates.periods.IsPeriod;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Millis;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Minutes;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Months;
@@ -66,6 +76,8 @@ import org.graylog.plugins.pipelineprocessor.functions.hashing.SHA512;
 import org.graylog.plugins.pipelineprocessor.functions.ips.CidrMatch;
 import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddress;
 import org.graylog.plugins.pipelineprocessor.functions.ips.IpAddressConversion;
+import org.graylog.plugins.pipelineprocessor.functions.ips.IsIp;
+import org.graylog.plugins.pipelineprocessor.functions.json.IsJson;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
@@ -96,6 +108,7 @@ import org.graylog.plugins.pipelineprocessor.functions.syslog.SyslogFacilityConv
 import org.graylog.plugins.pipelineprocessor.functions.syslog.SyslogLevelConversion;
 import org.graylog.plugins.pipelineprocessor.functions.syslog.SyslogPriorityConversion;
 import org.graylog.plugins.pipelineprocessor.functions.syslog.SyslogPriorityToStringConversion;
+import org.graylog.plugins.pipelineprocessor.functions.urls.IsUrl;
 import org.graylog.plugins.pipelineprocessor.functions.urls.UrlConversion;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog.plugins.pipelineprocessor.parser.ParseException;
@@ -252,6 +265,20 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(SyslogLevelConversion.NAME, new SyslogLevelConversion());
 
         functions.put(UrlConversion.NAME, new UrlConversion());
+
+        functions.put(IsBoolean.NAME, new IsBoolean());
+        functions.put(IsNumber.NAME, new IsNumber());
+        functions.put(IsDouble.NAME, new IsDouble());
+        functions.put(IsLong.NAME, new IsLong());
+        functions.put(IsString.NAME, new IsString());
+        functions.put(IsCollection.NAME, new IsCollection());
+        functions.put(IsList.NAME, new IsList());
+        functions.put(IsMap.NAME, new IsMap());
+        functions.put(IsDate.NAME, new IsDate());
+        functions.put(IsPeriod.NAME, new IsPeriod());
+        functions.put(IsIp.NAME, new IsIp());
+        functions.put(IsJson.NAME, new IsJson());
+        functions.put(IsUrl.NAME, new IsUrl());
 
         final GrokPatternService grokPatternService = mock(GrokPatternService.class);
         Set<GrokPattern> patterns = Sets.newHashSet(
@@ -635,6 +662,14 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.hasField("field_1")).isFalse();
         assertThat(message.hasField("field_2")).isTrue();
         assertThat(message.hasField("field_b")).isTrue();
+    }
+
+    @Test
+    public void comparisons() {
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final EvaluationContext context = contextForRuleEval(rule, new Message("", "", Tools.nowUTC()));
+        assertThat(context.hasEvaluationErrors()).isFalse();
+        assertThat(evaluateRule(rule)).isNotNull();
     }
 
     @Test

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/comparisons.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/comparisons.txt
@@ -1,0 +1,54 @@
+rule "comparison"
+when
+    is_string("") == true &&
+    is_string("foobar") == true &&
+    is_string(false) == false &&
+    is_string(1000) == false &&
+    is_string(1.234d) == false &&
+
+    is_bool(true) == true &&
+    is_bool(false) == true &&
+    is_bool("foobar") == false &&
+    is_bool(1234) == false &&
+    is_bool(23.42) == false &&
+
+    is_double(23.42) == true &&
+    is_double(23) == false &&
+    is_double(true) == false &&
+    is_double("foobar") == false &&
+
+    is_long(23) == true &&
+    is_long(23.42) == false &&
+    is_long(true) == false &&
+    is_long("foobar") == false &&
+
+    is_number(23) == true &&
+    is_number(23.42) == true &&
+    is_number(true) == false &&
+    is_number("foobar") == false &&
+
+    is_collection(["foobar", "foobaz"]) == true &&
+    is_collection({foo:"bar"}) == false &&
+    is_collection("foobar") == false &&
+    is_collection(true) == false &&
+    is_collection(23) == false &&
+    is_collection(23.42) == false &&
+    is_collection("foobar") == false &&
+
+    is_list(["foobar", "foobaz"]) == true &&
+    is_list({foo:"bar"}) == false &&
+    is_list("foobar") == false &&
+    is_list(true) == false &&
+    is_list(23) == false &&
+    is_list(23.42) == false &&
+    is_list("foobar") == false &&
+
+    is_map({foo:"bar"}) == true &&
+    is_map(["foobar", "foobaz"]) == false &&
+    is_map(true) == false &&
+    is_map(23) == false &&
+    is_map(23.42) == false &&
+    is_map("foobar") == false
+then
+    trigger_test();
+end

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dateArithmetic.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dateArithmetic.txt
@@ -19,8 +19,21 @@ when
     now() - minutes(1) < now() &&
     now() - seconds(1) < now() &&
     now() - millis(1) < now() &&
-    now() - period("P1YT1M") < now()
+    now() - period("P1YT1M") < now() &&
 
+    is_period(years(1)) == true &&
+    is_period(months(1)) == true &&
+    is_period(weeks(1)) == true &&
+    is_period(days(1)) == true &&
+    is_period(hours(1)) == true &&
+    is_period(minutes(1)) == true &&
+    is_period(seconds(1)) == true &&
+    is_period(millis(1)) == true &&
+    is_period(period("P1YT1M")) == true &&
+    is_period("foobar") == false &&
+    is_period(1234) == false &&
+    is_period(12.34) == false &&
+    is_period(true) == false
 then
     set_field("interval", now() - (now() - days(1))); // is a duration of 1 day
     set_field("long_time_ago", now() - years(10000));

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dates.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dates.txt
@@ -14,7 +14,11 @@ when
     parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") <= parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ") &&
     !(parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") > parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ")) &&
     parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") >= parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ") &&
-    !(parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") < parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ"))
+    !(parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") < parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ")) &&
+    is_date(now("CET")) == true &&
+    is_date("foobar") == false &&
+    is_date(1234) == false &&
+    is_date(12.34) == false
 then
     trigger_test();
     let date = parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ");

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/ipMatching.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/ipMatching.txt
@@ -1,7 +1,12 @@
 rule "ip handling"
 when
     cidr_match("192.0.0.0/8", to_ip("192.168.1.50")) &&
-    ! cidr_match("191.0.0.0/8", to_ip("192.168.1.50"))
+    ! cidr_match("191.0.0.0/8", to_ip("192.168.1.50")) &&
+    is_ip(to_ip("127.0.0.1")) == true &&
+    is_ip("foobar") == false &&
+    is_ip(1234) == false &&
+    is_ip(12.34) == false &&
+    is_ip(true) == false
 then
     set_field("ip_anon", to_string(to_ip($message.ip).anonymized));
     set_field("ipv6_anon", to_string(to_ip("2001:db8::1").anonymized));

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/jsonpath.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/jsonpath.txt
@@ -1,5 +1,10 @@
 rule "jsonpath"
-when true
+when
+  is_json(parse_json("{}")) == true &&
+  is_json("foobar") == false &&
+  is_json(1234) == false &&
+  is_json(12.34) == false &&
+  is_json(true) == false
 then
   let x = parse_json(to_string($message.message));
   let new_fields = select_jsonpath(x,

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/urls.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/urls.txt
@@ -1,6 +1,10 @@
 rule "urls"
 when
-    true
+    is_url("foobar") == false &&
+    is_url(1234) == false &&
+    is_url(12.34) == false &&
+    is_url(true) == false &&
+    is_url(to_url("http://example.org/")) == true
 then
     let url = to_url("https://admin:s3cr31@some.host.with.lots.of.subdomains.com:9999/path1/path2/three?q1=something&with_spaces=hello%20graylog&equal=can=containanotherone#anchorstuff");
     set_fields({


### PR DESCRIPTION
The comparison functions implemented in this change set enable users to run rules depending on the type of a variable (e. g. a message field).

Example:
```
rule "convert-custom-field-to-string"
when
    is_number($message.custom_field)
then
    set_field("custom_field", to_string($message.custom_field));
end
```