### PR TITLE
Add "parse_unix_milliseconds" functions

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -30,6 +30,7 @@ import org.graylog.plugins.pipelineprocessor.functions.dates.FlexParseDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FormatDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.Now;
 import org.graylog.plugins.pipelineprocessor.functions.dates.ParseDate;
+import org.graylog.plugins.pipelineprocessor.functions.dates.ParseUnixMilliseconds;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Days;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Hours;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Millis;
@@ -147,6 +148,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(DateConversion.NAME, DateConversion.class);
         addMessageProcessorFunction(Now.NAME, Now.class);
         addMessageProcessorFunction(ParseDate.NAME, ParseDate.class);
+        addMessageProcessorFunction(ParseUnixMilliseconds.NAME, ParseUnixMilliseconds.class);
         addMessageProcessorFunction(FlexParseDate.NAME, FlexParseDate.class);
         addMessageProcessorFunction(FormatDate.NAME, FormatDate.class);
         addMessageProcessorFunction(Years.NAME, Years.class);

--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/ParseUnixMilliseconds.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/dates/ParseUnixMilliseconds.java
@@ -1,0 +1,57 @@
+/**
+ * This file is part of Graylog Pipeline Processor.
+ *
+ * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Pipeline Processor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.dates;
+
+import com.google.common.collect.ImmutableList;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+public class ParseUnixMilliseconds extends TimezoneAwareFunction {
+    public static final String NAME = "parse_unix_milliseconds";
+
+    private static final String VALUE = "value";
+
+    private final ParameterDescriptor<Long, Long> valueParam;
+
+    public ParseUnixMilliseconds() {
+        valueParam = ParameterDescriptor.integer(VALUE).description("UNIX millisecond timestamp to parse").build();
+    }
+
+    @Override
+    protected String getName() {
+        return NAME;
+    }
+
+    @Override
+    protected ImmutableList<ParameterDescriptor> params() {
+        return ImmutableList.of(valueParam);
+    }
+
+    @Override
+    public DateTime evaluate(FunctionArgs args, EvaluationContext context, DateTimeZone timezone) {
+        final Long unixMillis = valueParam.required(args, context);
+        return unixMillis == null ? null : new DateTime(unixMillis, timezone);
+    }
+
+    @Override
+    protected String description() {
+        return "Converts a UNIX millisecond timestamp into a date";
+    }
+}

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -36,6 +36,7 @@ import org.graylog.plugins.pipelineprocessor.functions.dates.FlexParseDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.FormatDate;
 import org.graylog.plugins.pipelineprocessor.functions.dates.Now;
 import org.graylog.plugins.pipelineprocessor.functions.dates.ParseDate;
+import org.graylog.plugins.pipelineprocessor.functions.dates.ParseUnixMilliseconds;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Days;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Hours;
 import org.graylog.plugins.pipelineprocessor.functions.dates.periods.Millis;
@@ -208,6 +209,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(Now.NAME, new Now());
         functions.put(FlexParseDate.NAME, new FlexParseDate());
         functions.put(ParseDate.NAME, new ParseDate());
+        functions.put(ParseUnixMilliseconds.NAME, new ParseUnixMilliseconds());
         functions.put(FormatDate.NAME, new FormatDate());
 
         functions.put(Years.NAME, new Years());

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -368,6 +368,14 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
+    public void datesUnixTimestamps() {
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+        evaluateRule(rule);
+
+        assertThat(actionsTriggered.get()).isTrue();
+    }
+
+    @Test
     public void digests() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         evaluateRule(rule);

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dates.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dates.txt
@@ -14,7 +14,10 @@ when
     parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") <= parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ") &&
     !(parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") > parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ")) &&
     parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") >= parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ") &&
-    !(parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") < parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ"))
+    !(parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") < parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ")) &&
+    parse_unix_milliseconds(0) == parse_date("1970-01-01T00:00:00.000Z", "yyyy-MM-dd'T'HH:mm:ss.SSSZ") &&
+    parse_unix_milliseconds(1516272143555) == parse_date("2018-01-18T10:42:23.555Z", "yyyy-MM-dd'T'HH:mm:ss.SSSZ") &&
+    parse_unix_milliseconds(1516272143555, "Europe/Berlin") == parse_date(value: "2018-01-18T11:42:23.555", pattern: "yyyy-MM-dd'T'HH:mm:ss.SSS", timezone: "Europe/Berlin")
 then
     trigger_test();
     let date = parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ");

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dates.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dates.txt
@@ -14,10 +14,7 @@ when
     parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") <= parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ") &&
     !(parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") > parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ")) &&
     parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") >= parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ") &&
-    !(parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") < parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ")) &&
-    parse_unix_milliseconds(0) == parse_date("1970-01-01T00:00:00.000Z", "yyyy-MM-dd'T'HH:mm:ss.SSSZ") &&
-    parse_unix_milliseconds(1516272143555) == parse_date("2018-01-18T10:42:23.555Z", "yyyy-MM-dd'T'HH:mm:ss.SSSZ") &&
-    parse_unix_milliseconds(1516272143555, "Europe/Berlin") == parse_date(value: "2018-01-18T11:42:23.555", pattern: "yyyy-MM-dd'T'HH:mm:ss.SSS", timezone: "Europe/Berlin")
+    !(parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ") < parse_date("2010-07-30T16:03:25Z", "yyyy-MM-dd'T'HH:mm:ssZZ"))
 then
     trigger_test();
     let date = parse_date("2010-07-30T18:03:25+02:00", "yyyy-MM-dd'T'HH:mm:ssZZ");

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/datesUnixTimestamps.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/datesUnixTimestamps.txt
@@ -1,0 +1,8 @@
+rule "dates"
+when
+    parse_unix_milliseconds(0) == parse_date("1970-01-01T00:00:00.000Z", "yyyy-MM-dd'T'HH:mm:ss.SSSZ") &&
+    parse_unix_milliseconds(1516272143555) == parse_date("2018-01-18T10:42:23.555Z", "yyyy-MM-dd'T'HH:mm:ss.SSSZ") &&
+    parse_unix_milliseconds(1516272143555, "Europe/Berlin") == parse_date(value: "2018-01-18T11:42:23.555", pattern: "yyyy-MM-dd'T'HH:mm:ss.SSS", timezone: "Europe/Berlin")
+then
+    trigger_test();
+end


### PR DESCRIPTION
The `parse_unix_milliseconds()` function enables users to parse a UNIX epoch timestamp in milliseconds into a date object.