### PR TITLE
Handle PipelineInterpreter.State event to avoid warning in the log

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdater.java
@@ -1,5 +1,6 @@
 package org.graylog.plugins.pipelineprocessor.processors;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -7,9 +8,6 @@ import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
-
-import com.codahale.metrics.MetricRegistry;
-
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
 import org.graylog.plugins.pipelineprocessor.codegen.PipelineClassloader;
@@ -26,6 +24,11 @@ import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.tools.ToolProvider;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -33,12 +36,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-
-import javax.annotation.Nonnull;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-import javax.tools.ToolProvider;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
@@ -216,6 +213,11 @@ public class ConfigurationStateUpdater {
     public void handlePipelineConnectionChanges(PipelineConnectionsChangedEvent event) {
         log.debug("Pipeline stream connection changed: {}", event);
         scheduler.schedule(() -> serverEventBus.post(reloadAndSave()), 0, TimeUnit.SECONDS);
+    }
+
+    @Subscribe
+    public void handlePipelineStateChange(PipelineInterpreter.State event) {
+        log.debug("Pipeline interpreter state got updated");
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Fixes #236

Notice: This needs to be **cherry-picked into 2.4** once merged