### PR TITLE
Stabilize date/time based tests

### DIFF
--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/BaseParserTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/BaseParserTest.java
@@ -32,6 +32,7 @@ import org.graylog.plugins.pipelineprocessor.parser.PipelineRuleParser;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.rules.TestName;
@@ -142,7 +143,7 @@ public class BaseParserTest {
 
     @Nullable
     protected Message evaluateRule(Rule rule, Consumer<Message> messageModifier) {
-        final Message message = new Message("hello test", "source", DateTime.now());
+        final Message message = new Message("hello test", "source", DateTime.now(DateTimeZone.UTC));
         message.addStream(defaultStream);
         messageModifier.accept(message);
         return evaluateRule(rule, message);

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -360,6 +360,9 @@ public class FunctionsSnippetsTest extends BaseParserTest {
             assertThat(message.getField("french_month")).isEqualTo(7);
             assertThat(message.getField("french_day")).isEqualTo(24);
 
+            assertThat(message.getField("ts_hour")).isEqualTo(16);
+            assertThat(message.getField("ts_minute")).isEqualTo(3);
+            assertThat(message.getField("ts_second")).isEqualTo(25);
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
         }

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dates.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/dates.txt
@@ -36,4 +36,8 @@ then
     set_field("french_day", frenchDate.dayOfMonth);
     set_field("french_month", frenchDate.monthOfYear);
     set_field("french_year", frenchDate.year);
+
+    set_field("ts_hour", $message.timestamp.hourOfDay);
+    set_field("ts_minute", $message.timestamp.minuteOfHour);
+    set_field("ts_second", $message.timestamp.secondOfMinute);
 end


### PR DESCRIPTION
The message timestamp used to be in the system default locale instead of UTC.

Additionally, this commit adds tests/examples for accessing individual components of the message timestamp in a pipeline rule.