### PR TITLE
Fix KeyValue rule function to split entries once

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/KeyValue.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/KeyValue.java
@@ -82,6 +82,7 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
 
         final Splitter entrySplitter = Splitter.on(kvDelimMatcher)
                 .omitEmptyStrings()
+                .limit(2)
                 .trimResults();
         return new MapSplitter(outerSplitter,
                                entrySplitter,

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -735,7 +735,8 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("e")).isEqualTo("4");
         assertThat(message.getField("f")).isEqualTo("1");
         assertThat(message.getField("g")).isEqualTo("3");
-        assertThat(message.hasField("h")).isFalse();
+        assertThat(message.getField("h")).isEqualTo("3=:3");
+        assertThat(message.hasField("i")).isFalse();
 
         assertThat(message.getField("dup_first")).isEqualTo("1");
         assertThat(message.getField("dup_last")).isEqualTo("2");

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/keyValue.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/keyValue.txt
@@ -2,7 +2,7 @@ rule "kv"
 when true
 then
     set_fields(key_value(
-            value: "a='1' <b>=2  \n 'c'=3 [d]=44 a=4 \"e\"=4 [f=1][[g]:3] h=",
+            value: "a='1' <b>=2  \n 'c'=3 [d]=44 a=4 \"e\"=4 [f=1][[g]:3] 'h'=3=:3 i=",
             delimiters: " \t\n\r[",
             kv_delimiters: "=:",
             ignore_empty_values: true,


### PR DESCRIPTION
Prevent splitting values if delimiter chars are found inside values

Fixes Graylog2/graylog2-server#4920

(cherry picked from Graylog2/graylog2-server@cfcb622ce in Graylog2/graylog2-server#4927)