### PR TITLE
Add support for decimal IPv4 representation in to_ip pipeline function

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddressConversion.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddressConversion.java
@@ -44,11 +44,14 @@ public class IpAddressConversion extends AbstractFunction<IpAddress> {
 
     @Override
     public IpAddress evaluate(FunctionArgs args, EvaluationContext context) {
-        final String ipString = String.valueOf(ipParam.required(args, context));
-
+        final Object ip = ipParam.required(args, context);
         try {
-            final InetAddress inetAddress = InetAddresses.forString(ipString);
-            return new IpAddress(inetAddress);
+            if (ip instanceof Number) {
+                // this is only valid for IPv4 addresses, v6 requires 128 bits which we don't support
+                return new IpAddress(InetAddresses.fromInteger(((Number) ip).intValue()));
+            } else {
+                return new IpAddress(InetAddresses.forString(String.valueOf(ip)));
+            }
         } catch (IllegalArgumentException e) {
             final Optional<String> defaultValue = defaultParam.optional(args, context);
             if (!defaultValue.isPresent()) {

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -845,4 +845,12 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message).isNotNull();
         assertThat(message.getStreams()).containsOnly(defaultStream);
     }
+
+    @Test
+    public void int2ipv4() {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        evaluateRule(rule);
+
+        assertThat(actionsTriggered.get()).isTrue();
+    }
 }

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/int2ipv4.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/int2ipv4.txt
@@ -1,0 +1,5 @@
+rule "int2ipv4"
+when to_ip("8.8.8.8") == to_ip(134744072)
+then
+   trigger_test();
+end


### PR DESCRIPTION
if the argument is a number, try to convert its intValue into an IP address
otherwise the previous behavior of taking the string value and converting that applies

Fixes Graylog2/graylog2-server#5268

Backport of Graylog2/graylog2-server@8e77a4d53