### PR TITLE
properly handle IPv6 addresses in IPv4 subnet check

### DIFF
--- a/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/CidrMatch.java
+++ b/plugin/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/CidrMatch.java
@@ -21,7 +21,7 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
-import org.jboss.netty.handler.ipfilter.CIDR;
+import org.graylog2.utilities.IpSubnet;
 
 import java.net.UnknownHostException;
 
@@ -32,14 +32,14 @@ public class CidrMatch extends AbstractFunction<Boolean> {
     public static final String NAME = "cidr_match";
     public static final String IP = "ip";
 
-    private final ParameterDescriptor<String, CIDR> cidrParam;
+    private final ParameterDescriptor<String, IpSubnet> cidrParam;
     private final ParameterDescriptor<IpAddress, IpAddress> ipParam;
 
     public CidrMatch() {
         // a little ugly because newCIDR throws a checked exception :(
-        cidrParam = ParameterDescriptor.string("cidr", CIDR.class).transform(cidrString -> {
+        cidrParam = ParameterDescriptor.string("cidr", IpSubnet.class).transform(cidrString -> {
             try {
-                return CIDR.newCIDR(cidrString);
+                return new IpSubnet(cidrString);
             } catch (UnknownHostException e) {
                 throw new IllegalArgumentException(e);
             }
@@ -49,7 +49,7 @@ public class CidrMatch extends AbstractFunction<Boolean> {
 
     @Override
     public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
-        final CIDR cidr = cidrParam.required(args, context);
+        final IpSubnet cidr = cidrParam.required(args, context);
         final IpAddress ipAddress = ipParam.required(args, context);
         if (cidr == null || ipAddress == null) {
             return null;

--- a/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/plugin/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -623,6 +623,14 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
+    public void ipMatchingIssue5405() {
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+        evaluateRule(rule);
+
+        assertThat(actionsTriggered.get()).isTrue();
+    }
+
+    @Test
     public void fieldRenaming() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
 

--- a/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/ipMatchingIssue5405.txt
+++ b/plugin/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/ipMatchingIssue5405.txt
@@ -1,0 +1,8 @@
+rule "cidr_with_ipv6"
+when
+    cidr_match("10.0.0.0/8", to_ip("10.1.2.3")) &&
+    !cidr_match("10.0.0.0/8", to_ip("dummy")) &&
+    !cidr_match("10.0.0.0/8", to_ip("2001:db8::1"))
+then
+  trigger_test();
+end


### PR DESCRIPTION
the class from netty3 improperly threw an exception when checking an unmappable v6 address against a v4 cdir pattern
using the custom subnet class from Graylog fixes these issues

fixes Graylog2/graylog2-server#5405